### PR TITLE
JSON Schema

### DIFF
--- a/schema/v0_0_10/examples/20181005-1091_Pool_start_v0.2.qc.json
+++ b/schema/v0_0_10/examples/20181005-1091_Pool_start_v0.2.qc.json
@@ -1,274 +1,252 @@
 {
     "qcML": {
-        "_version": "0.1.0",
-	"__comment": "The above is a speculative schema version since we haven't updated in some time.",
-        "runQuality": {
-            "metaDataParameters": {
-                "InputFiles": [
-                    {
-                        "RawFile": {
-                            "_id": "rawfile001",
-                            "_location": "file://c:/Research/20171124-Lizex-Chia/1091_Pool_start.mzML",
-                            "FileFormat": {
-                                "_cvRef": "MS",
-                                "_accession": "MS:1000584",
-                                "_name": "mzML format"
-                            },
-                            "FileProperties": [
-                                {
-                                    "_cvRef": "MS",
-                                    "_accession": "MS:1000568",
-                                    "_name": "MD5",
-                                    "_value": "b583f6d2a91b4749d5a75885330f6e5d"
+        "version": "0.0.1",
+        "runQuality": [
+            {
+                "metadata": {
+                    "inputFiles": [
+                        {
+                            "rawFile": {
+                                "location": "file:///c:/Research/20171124-Lizex-Chia/1091_Pool_start.mzML",
+                                "fileFormat": {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000584",
+                                    "name": "mzML format"
                                 },
-                                {
-                                    "_cvRef": "MS",
-                                    "_accession": "MS:1000747",
-                                    "_name": "completion time",
-                                    "_value": "2017-12-08-T15:38:57Z"
-                                }
-                            ]
+                                "fileProperties": [
+                                    {
+                                        "cvRef": "MS",
+                                        "accession": "MS:1000568",
+                                        "name": "MD5",
+                                        "value": "b583f6d2a91b4749d5a75885330f6e5d"
+                                    },
+                                    {
+                                        "cvRef": "MS",
+                                        "accession": "MS:1000747",
+                                        "name": "completion time",
+                                        "value": "2017-12-08-T15:38:57Z"
+                                    }
+                                ]
+                            }
                         }
-                    }
-                ],
-                "AnalysisSoftware": [
+                    ],
+                    "analysisSoftware": [
+                        {
+                            "cvRef": "MS",
+                            "accession": "MS:1009002",
+                            "name": "QuaMeter IDFree",
+                            "version": "1.1.10165",
+                            "uri": "http://proteowizard.sourceforge.net/"
+                        }
+                    ]
+                },
+                "qualityParameters": [
                     {
-                        "_cv": {
-                            "_cvRef": "MS",
-                            "_accession": "MS:1009002",
-                            "_name": "QuaMeter IDFree"
+                        "cvRef": "QC",
+                        "accession": "QC:4000050",
+                        "name": "Quameter metric: XIC-WideFrac",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000191",
+                            "name": "fraction"
                         },
-                        "_version": "1.1.10165",
-                        "_uri": "http://proteowizard.sourceforge.net/"
+                        "value": 0.206807
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000051",
+                        "name": "Quameter metric: XIC-FWHM Q1-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000010",
+                            "name": "second"
+                        },
+                        "value": [12.5377, 14.2244, 16.9234]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000052",
+                        "name": "Quameter metric: XIC-FWHM Q1-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000006",
+                            "name": "ratio"
+                        },
+                        "value": [0.776393, 0.93114, 6.6283]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000053",
+                        "name": "Quameter metric: RT-Duration",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000010",
+                            "name": "second"
+                        },
+                        "value": 4920.17
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000054",
+                        "name": "Quameter metric: XIC-FWHM Q1-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000191",
+                            "name": "fraction"
+                        },
+                        "value": [0.301236, 0.13286, 0.174576, 0.391328]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000055",
+                        "name": "Quameter metric: RT-MS1 Q1-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000191",
+                            "name": "fraction"
+                        },
+                        "value": [0.217794, 0.272976, 0.275845, 0.233385]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000056",
+                        "name": "Quameter metric: RT-MS2 Q1-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000191",
+                            "name": "fraction"
+                        },
+                        "value": [0.268157, 0.233516, 0.236373, 0.261954]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000057",
+                        "name": "Quameter metric: MS1-TIC-Change Q2-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0010006",
+                            "name": "ratio"
+                        },
+                        "value": [0.870774, 0.900585, 4.66521]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000058",
+                        "name": "Quameter metric: MS1-TIC Q2-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0010006",
+                            "name": "ratio"
+                        },
+                        "value": [0.568866, 0.815636, 1.18124]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000059",
+                        "name": "Quameter metric: MS1-Count",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000189",
+                            "name": "count"
+                        },
+                        "value": 7832
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000000",
+                        "name": "Quameter metric: MS1-Freq-Max",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000106",
+                            "name": "Hertz"
+                        },
+                        "value": 2.41814
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000000",
+                        "name": "Quameter metric: MS1-Density Q1-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000189",
+                            "name": "count"
+                        },
+                        "value": [693, 1205, 1424]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000060",
+                        "name": "Quameter metric: MS2-Count",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000189",
+                            "name": "count"
+                        },
+                        "value": 33495
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000061",
+                        "name": "Quameter metric: MS2-Freq-Max",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000106",
+                            "name": "Hertz"
+                        },
+                        "value": 7.33107
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000062",
+                        "name": "Quameter metric: MS2-Density Q1-Qn",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000189",
+                            "name": "count"
+                        },
+                        "value": [27, 44, 70]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000063",
+                        "name": "Quameter metric: MS2-PrecZ-Known",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000191",
+                            "name": "fraction"
+                        },
+                        "value": [0, 0.15047, 0.0687565, 0.00877743, 0.000507538, 0.000268697]
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:4000064",
+                        "name": "Quameter metric: MS2-PrecZ-Unknown",
+                        "unit": {
+                            "cvRef": "UO",
+                            "accession": "UO:0000191",
+                            "name": "fraction"
+                        },
+                        "value": [0.54235, 0.22887]
                     }
                 ]
-            },
-            "qualityParameters": [
-                {
-                    "_id": "XIC-WideFrac",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000050",
-                    "_name": "Quameter metric: XIC-WideFrac",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000191",
-                        "_name": "fraction"
-                    },
-                    "_value": 0.206807
-                },
-                {
-                    "_id": "XIC-FWHM",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000051",
-                    "_name": "Quameter metric: XIC-FWHM Q1-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000010",
-                        "_name": "second"
-                    },
-                    "_value": [12.5377,14.2244,16.9234]
-                },
-                {
-                    "_id": "XIC-Height",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000052",
-                    "_name": "Quameter metric: XIC-FWHM Q1-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000006",
-                        "_name": "ratio"
-                    },
-                    "_value": [0.776393,0.93114,6.6283]
-                },
-                {
-                    "_id": "RT-Duration",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000053",
-                    "_name": "Quameter metric: RT-Duration",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000010",
-                        "_name": "second"
-                    },
-                    "_value": 4920.17
-                },
-                {
-                    "_id": "RT-TIC",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000054",
-                    "_name": "Quameter metric: XIC-FWHM Q1-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000191",
-                        "_name": "fraction"
-                    },
-                    "_value": [0.301236,0.13286,0.174576,0.391328]
-                },
-                {
-                    "_id": "RT-MS1",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000055",
-                    "_name": "Quameter metric: RT-MS1 Q1-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000191",
-                        "_name": "fraction"
-                    },
-                    "_value": [0.217794,0.272976,0.275845,0.233385]
-                },
-                {
-                    "_id": "RT-MS2",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000056",
-                    "_name": "Quameter metric: RT-MS2 Q1-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000191",
-                        "_name": "fraction"
-                    },
-                    "_value": [0.268157,0.233516,0.236373,0.261954]
-                },
-                {
-                    "_id": "MS1-TIC-Change",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000057",
-                    "_name": "Quameter metric: MS1-TIC-Change Q2-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0010006",
-                        "_name": "ratio"
-                    },
-                    "_value": [0.870774,0.900585,4.66521]
-                },
-                {
-                    "_id": "MS1-TIC",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000058",
-                    "_name": "Quameter metric: MS1-TIC Q2-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0010006",
-                        "_name": "ratio"
-                    },
-                    "_value": [0.568866,0.815636,1.18124]
-                },
-                {
-                    "_id": "MS1-Count",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000059",
-                    "_name": "Quameter metric: MS1-Count",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000189",
-                        "_name": "count"
-                    },
-                    "_value": 7832
-                },
-                {
-                    "_id": "MS1-Freq-Max",
-                    "_cvRef": "QC",
-                    "_accession": "QC:TODO",
-                    "_name": "Quameter metric: MS1-Freq-Max",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000106",
-                        "_name": "Hertz"
-                    },
-                    "_value": 2.41814
-                },
-                {
-                    "_id": "MS1-Density",
-                    "_cvRef": "QC",
-                    "_accession": "QC:TODO",
-                    "_name": "Quameter metric: MS1-Density Q1-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000189",
-                        "_name": "count"
-                    },
-                    "_value": [693,1205,1424]
-                },
-                {
-                    "_id": "MS2-Count",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000060",
-                    "_name": "Quameter metric: MS2-Count",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000189",
-                        "_name": "count"
-                    },
-                    "_value": 33495
-                },
-                {
-                    "_id": "MS2-Freq-Max",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000061",
-                    "_name": "Quameter metric: MS2-Freq-Max",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000106",
-                        "_name": "Hertz"
-                    },
-                    "_value": 7.33107
-                },
-                {
-                    "_id": "MS2-Density",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000062",
-                    "_name": "Quameter metric: MS2-Density Q1-Qn",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000189",
-                        "_name": "count"
-                    },
-                    "_value": [27,44,70]
-                },
-                {
-                    "_id": "MS2-PrecZ-Known",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000063",
-                    "_name": "Quameter metric: MS2-PrecZ-Known",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000191",
-                        "_name": "fraction"
-                    },
-                    "_value": [0,0.15047,0.0687565,0.00877743,0.000507538,0.000268697]
-                },
-                {
-                    "_id": "MS2-PrecZ-Unknown",
-                    "_cvRef": "QC",
-                    "_accession": "QC:4000064",
-                    "_name": "Quameter metric: MS2-PrecZ-Unknown",
-                    "_unit": {
-                        "_cvRef": "UO",
-                        "_accession": "UO:0000191",
-                        "_name": "fraction"
-                    },
-                    "_value": [0.54235,0.22887]
-                }
-            ]
-        }
-    },
-    "cv": [
-        {
-            "_id": "QC",
-            "_name": "Proteomics Standards Initiative Quality Control Ontology",
-            "_version": "0.1.0",
-            "_uri": "https://github.com/HUPO-PSI/qcML-development/blob/master/cv/v0_0_11/qc-cv.obo"
-        },
-        {
-            "_id": "MS",
-            "_name": "Proteomics Standards Initiative Mass Spectrometry Ontology",
-            "_version": "4.1.7",
-            "_uri": "https://github.com/HUPO-PSI/psi-ms-CV/blob/master/psi-ms.obo"
-        },
-        {
-            "_id": "UO",
-            "_name": "Unit Ontology",
-            "_version": "09:04:2014 13:37",
-            "_uri": "https://github.com/bio-ontology-research-group/unit-ontology/blob/master/unit.obo"
-        }
-    ]
+            }
+        ],
+       "cv": {
+           "QC": {
+               "name": "Proteomics Standards Initiative Quality Control Ontology",
+               "uri": "https://github.com/HUPO-PSI/qcML-development/blob/master/cv/v0_0_11/qc-cv.obo",
+               "version": "0.1.0"
+           },
+           "MS": {
+               "name": "Proteomics Standards Initiative Mass Spectrometry Ontology",
+               "uri": "https://github.com/HUPO-PSI/psi-ms-CV/blob/master/psi-ms.obo",
+               "version": "4.1.7"
+           },
+           "UO": {
+               "name": "Unit Ontology",
+               "uri": "https://github.com/bio-ontology-research-group/unit-ontology/blob/master/unit.obo",
+               "version": "09:04:2014 13:37"
+           }
+       }
+   }
 }

--- a/schema/v0_0_10/mzqc_0_0_10.schema.json
+++ b/schema/v0_0_10/mzqc_0_0_10.schema.json
@@ -1,0 +1,221 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://github.com/HUPO-PSI/qcML-development/tree/master/schema/v0_0_10/mzqc_0_0_10.schema.json",
+	"title": "mzQC schema v0.0.10",
+	"description": "JSON schema specifying the mzQC format v0.0.10 developed by the HUPO-PSI Quality Control working group (http://psidev.info/groups/quality-control).",
+	"type": "object",
+	"properties": {
+		"qcML": {
+			"description": "Root qcML element.",
+			"type": "object",
+			"properties": {
+				"version": {
+					"description": "Version number of the relevant mzQC JSON schema.",
+					"type": "string",
+					"pattern": "^\\d+\\.\\d+\\.\\d+$"
+				},
+				"runQuality": {
+					"description": "List of runQuality elements.",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/runQuality"
+					}
+				},
+				"setQuality": {
+					"description": "List of setQuality elements.",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/setQuality"
+					}
+				},
+				"cv": {
+					"description": "Collection of CV elements.",
+					"type": "object",
+					"patternProperties": {
+						"[A-Z]{2}": {
+							"$ref": "#/definitions/cv"
+						}
+					},
+					"minProperties": 1
+				}
+			},
+			"additionalProperties": false,
+			"oneOf": [
+				{"required": ["runQuality"]},
+				{"required": ["setQuality"]}
+			],
+			"required": ["version", "cv"]
+		}
+	},
+	"additionalProperties": false,
+	"required": ["qcML"],
+	"definitions": {
+		"baseQuality": {
+			"description": "Base element describing a runQuality or setQuality.",
+			"type": "object",
+			"properties": {
+				"metadata": {
+					"$ref": "#/definitions/metadata"
+				},
+				"qualityParameters": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/qualityParameter"
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": ["metadata", "qualityParameters"]
+		},
+		"runQuality": {
+			"description": "Parent element describing QC metrics for a single run.",
+			"$ref": "#/definitions/baseQuality"
+		},
+		"setQuality": {
+			"description": "Parent element describing combined QC metrics for multiple runs.",
+			"$ref": "#/definitions/baseQuality"
+		},
+		"cvParameter": {
+			"description": "Base element containing a reference to a controlled vocabulary.",
+			"type": "object",
+			"properties": {
+				"cvRef": {
+					"description": "Reference to the CV that contains the parameter definition.",
+					"type": "string",
+					"pattern": "^[A-Z]{2}$"
+				},
+				"accession": {
+					"description": "Accession number identifying the parameter within its CV.",
+					"type": "string",
+					"pattern": "^[A-Z]{2}:[0-9]{7}$"
+				},
+				"name": {
+					"description": "Name of the CV element describing the parameter.",
+					"type": "string"
+				},
+				"description": {
+					"description": "Description of the parameter.",
+					"type": "string"
+				},
+				"value": {
+					"description": "Value of the parameter."
+				},
+				"unit": {
+					"description": "A CV element describing the unit of the parameter value.",
+					"$ref": "#/definitions/cvParameter"
+				}
+			},
+			"required": ["cvRef", "accession", "name"]
+		},
+		"metadata": {
+			"description": "Metadata describing the QC analysis.",
+			"type": "object",
+			"properties": {
+				"inputFiles": {
+					"description": "List of input files based on which the QC metrics were generated.",
+					"type": "array",
+					"minItems": 1,
+					"items": [
+						{
+							"type": "object",
+							"properties": {
+								"rawFile": {
+									"description": "Raw spectral file based on which QC metrics were generated.",
+									"$ref": "#/definitions/inputFile"
+								}
+							}
+						}
+					],
+					"additionalItems": {
+						"$ref": "#/definitions/inputFile"
+					}
+				},
+				"analysisSoftware": {
+					"description": "Software tool(s) used to generate the QC metrics.",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"allOf": [
+							{
+								"$ref": "#/definitions/cvParameter"
+							},
+							{
+								"properties": {
+									"version": {
+										"description": "Version number of the software tool.",
+										"type": "string"
+									},
+									"uri": {
+										"description": "Publicly accessible URI of the software tool.",
+										"type": "string",
+										"format": "uri"
+									}
+								},
+								"required": ["version", "uri"]
+							}
+						]
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": ["inputFiles", "analysisSoftware"]
+		},
+		"inputFile": {
+			"description": "File based on which QC metrics were generated.",
+			"type": "object",
+			"properties": {
+				"location": {
+					"description": "Unique file location, preferably publicly accessible.",
+					"type": "string",
+					"format": "uri"
+				},
+				"name": {
+					"description": "Base file name, should be unique across the mzQC file.",
+					"type": "string"
+				},
+				"fileFormat": {
+					"description": "Type of input file.",
+					"$ref": "#/definitions/cvParameter"
+				},
+				"fileProperties": {
+					"description": "Detailed properties of the input file.",
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/cvParameter"
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": ["location", "fileFormat"]
+		},
+		"qualityParameter": {
+			"description": "Parameter describing a QC metric.",
+			"$ref": "#/definitions/cvParameter"
+		},
+		"cv": {
+			"description": "Element describing a controlled vocabulary.",
+			"type": "object",
+			"properties": {
+				"name": {
+					"description": "Full name of the CV.",
+					"type": "string"
+				},
+				"uri": {
+					"description": "Publicly accessible URI of the CV.",
+					"type": "string",
+					"format": "uri"
+				},
+				"version": {
+					"description": "Version of the CV.",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"required": ["name", "uri"]
+		}
+	}
+}

--- a/schema/v0_0_11/README.md
+++ b/schema/v0_0_11/README.md
@@ -1,0 +1,28 @@
+# README
+
+Description of mzQC schema v0.0.11:
+
+- Root element `mzQC`.
+    - Required `version` of regex `\d+.\d+.\d+`.
+    - Required list of `cv`s.
+    - Required either a list of `runQuality` or a list of `setQuality`. This list needs to have at least one element, while an unbounded maximum is allowed. Lists of both `runQuality` and `setQuality` can be present simultaneously.
+
+- `runQuality`/`setQuality`: Exactly the same, only the key is different.
+    - Required `metadata`.
+        - Required list of at least one `inputFile`.
+            - Required properties `location` (URI), `name`, and `fileFormat`.
+            - Optional list of `fileProperties`, which contains elements referring to CV entries.
+        - Required list of at least one `analysisSoftware`.
+            - Required attributes to refer to a CV entry.
+            - Additional required attributes `version` and `uri`.
+    - Required list of at least one `qualityParameter`.
+        - Required attributes to refer to a CV entry: `cvRef`, `accession`, `name`.
+        - Optional attributes: `description`, `value`, `unit`.
+        - `unit` is a similar sub-element referring to CV entry.
+        - `value` can be anything: string, number, list, nested element. We have to do semantic validation based on information from the CV.
+
+- `cv`: References to controlled vocabularies.
+    - `key` = short (uppercase) string uniquely identifying the CV. To be used by the `cvRef` property in the parameters.
+    - `value` = Element containing the CV information.
+        - Required attributes: `name`, `uri`.
+        - Optional attribute: `version`.

--- a/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
+++ b/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
@@ -7,7 +7,7 @@
                     "inputFiles": [
                         {
                             "location": "file:///c:/Research/20171124-Lizex-Chia/1091_Pool_start.mzML",
-                            "name": "1091_Pool_start.mzML",
+                            "name": "1091_Pool_start",
                             "fileFormat": {
                                 "cvRef": "MS",
                                 "accession": "MS:1000584",

--- a/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
+++ b/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
@@ -1,5 +1,5 @@
 {
-    "qcML": {
+    "mzQC": {
         "version": "0.0.11",
         "runQuality": [
             {

--- a/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
+++ b/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
@@ -7,6 +7,7 @@
                     "inputFiles": [
                         {
                             "location": "file:///c:/Research/20171124-Lizex-Chia/1091_Pool_start.mzML",
+                            "name": "1091_Pool_start.mzML",
                             "fileFormat": {
                                 "cvRef": "MS",
                                 "accession": "MS:1000584",

--- a/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
+++ b/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
@@ -6,28 +6,26 @@
                 "metadata": {
                     "inputFiles": [
                         {
-                            "rawFile": {
-                                "location": "file:///c:/Research/20171124-Lizex-Chia/1091_Pool_start.mzML",
-                                "fileFormat": {
+                            "location": "file:///c:/Research/20171124-Lizex-Chia/1091_Pool_start.mzML",
+                            "fileFormat": {
+                                "cvRef": "MS",
+                                "accession": "MS:1000584",
+                                "name": "mzML format"
+                            },
+                            "fileProperties": [
+                                {
                                     "cvRef": "MS",
-                                    "accession": "MS:1000584",
-                                    "name": "mzML format"
+                                    "accession": "MS:1000568",
+                                    "name": "MD5",
+                                    "value": "b583f6d2a91b4749d5a75885330f6e5d"
                                 },
-                                "fileProperties": [
-                                    {
-                                        "cvRef": "MS",
-                                        "accession": "MS:1000568",
-                                        "name": "MD5",
-                                        "value": "b583f6d2a91b4749d5a75885330f6e5d"
-                                    },
-                                    {
-                                        "cvRef": "MS",
-                                        "accession": "MS:1000747",
-                                        "name": "completion time",
-                                        "value": "2017-12-08-T15:38:57Z"
-                                    }
-                                ]
-                            }
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000747",
+                                    "name": "completion time",
+                                    "value": "2017-12-08-T15:38:57Z"
+                                }
+                            ]
                         }
                     ],
                     "analysisSoftware": [

--- a/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
+++ b/schema/v0_0_11/examples/20181005-1091_Pool_start_v0.2.qc.json
@@ -1,6 +1,6 @@
 {
     "qcML": {
-        "version": "0.0.1",
+        "version": "0.0.11",
         "runQuality": [
             {
                 "metadata": {

--- a/schema/v0_0_11/examples/iPRG2015_sample1.qc.json
+++ b/schema/v0_0_11/examples/iPRG2015_sample1.qc.json
@@ -1,0 +1,417 @@
+{
+    "mzQC": {
+        "version": "0.0.11",
+        "runQuality": [
+            {
+                "metadata": {
+                    "inputFiles": [
+                        {
+                            "location": "file:///hps/nobackup/proteomics/conversion_comparison/iPRG2015/JD_06232014_sample1_A.mzML",
+                            "name": "JD_06232014_sample1_A",
+                            "fileFormat": {
+                                "cvRef": "MS",
+                                "accession": "MS:1000584",
+                                "name": "mzML format"
+                            },
+                            "fileProperties": [
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000569",
+                                    "name": "SHA-1",
+                                    "value": "eb3ce615ed4d73a1f532c561b17be5cefa88d520"
+                                },
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000747",
+                                    "name": "completion time",
+                                    "value": "2017-12-18+15:09"
+                                }
+                            ]
+                        }
+                    ],
+                    "analysisSoftware": [
+                        {
+                            "cvRef": "MS",
+                            "accession": "MS:1000752",
+                            "name": "TOPP software",
+                            "version": "2.4.0",
+                            "uri": "http://OpenMS.de/"
+                        }
+                    ]
+                },
+                "qualityParameters": [
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000006",
+                        "name": "MS1 spectra count",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 7787
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000007",
+                        "name": "MS2 spectra count",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 49514
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000037",
+                        "name": "total number of missed cleavages",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 4692
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000032",
+                        "name": "total number of identified proteins",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 3733
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000029",
+                        "name": "total number of PSMs",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 24328
+                    }
+                ]
+            },
+            {
+                "metadata": {
+                    "inputFiles": [
+                        {
+                            "location": "file:///hps/nobackup/proteomics/conversion_comparison/iPRG2015/JD_06232014_sample1_B.mzML",
+                            "name": "JD_06232014_sample1_B",
+                            "fileFormat": {
+                                "cvRef": "MS",
+                                "accession": "MS:1000584",
+                                "name": "mzML format"
+                            },
+                            "fileProperties": [
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000569",
+                                    "name": "SHA-1",
+                                    "value": "8efe8d4e568e79b62fd25cad50a1ec4127dc1996"
+                                },
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000747",
+                                    "name": "completion time",
+                                    "value": "2017-12-18+15:13"
+                                }
+                            ]
+                        }
+                    ],
+                    "analysisSoftware": [
+                        {
+                            "cvRef": "MS",
+                            "accession": "MS:1000752",
+                            "name": "TOPP software",
+                            "version": "2.4.0",
+                            "uri": "http://OpenMS.de/"
+                        }
+                    ]
+                },
+                "qualityParameters": [
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000006",
+                        "name": "MS1 spectra count",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 7764
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000007",
+                        "name": "MS2 spectra count",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 49633
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000037",
+                        "name": "total number of missed cleavages",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 4844
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000032",
+                        "name": "total number of identified proteins",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 3807
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000029",
+                        "name": "total number of PSMs",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 25229
+                    }
+                ]
+            },
+            {
+                "metadata": {
+                    "inputFiles": [
+                        {
+                            "location": "file:///hps/nobackup/proteomics/conversion_comparison/iPRG2015/JD_06232014_sample1_C.mzML",
+                            "name": "JD_06232014_sample1_C",
+                            "fileFormat": {
+                                "cvRef": "MS",
+                                "accession": "MS:1000584",
+                                "name": "mzML format"
+                            },
+                            "fileProperties": [
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000569",
+                                    "name": "SHA-1",
+                                    "value": "acb9e0f8c3cc93de10637e594d5f2299191b0b9e"
+                                },
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000747",
+                                    "name": "completion time",
+                                    "value": "2017-12-18+15:17"
+                                }
+                            ]
+                        }
+                    ],
+                    "analysisSoftware": [
+                        {
+                            "cvRef": "MS",
+                            "accession": "MS:1000752",
+                            "name": "TOPP software",
+                            "version": "2.4.0",
+                            "uri": "http://OpenMS.de/"
+                        }
+                    ]
+                },
+                "qualityParameters": [
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000006",
+                        "name": "MS1 spectra count",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 7802
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000007",
+                        "name": "MS2 spectra count",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 49334
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000037",
+                        "name": "total number of missed cleavages",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 4420
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000032",
+                        "name": "total number of identified proteins",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 3608
+                    },
+                    {
+                        "cvRef": "QC",
+                        "accession": "QC:0000029",
+                        "name": "total number of PSMs",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000047",
+                            "name": "count"
+                        },
+                        "value": 22913
+                    }
+                ]
+            }
+        ],
+        "setQuality": [
+            {
+                "metadata": {
+                    "inputFiles": [
+                        {
+                            "location": "file:///hps/nobackup/proteomics/conversion_comparison/iPRG2015/JD_06232014_sample1_A.mzML",
+                            "name": "JD_06232014_sample1_A",
+                            "fileFormat": {
+                                "cvRef": "MS",
+                                "accession": "MS:1000584",
+                                "name": "mzML format"
+                            },
+                            "fileProperties": [
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000569",
+                                    "name": "SHA-1",
+                                    "value": "eb3ce615ed4d73a1f532c561b17be5cefa88d520"
+                                },
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000747",
+                                    "name": "completion time",
+                                    "value": "2017-12-18+15:09"
+                                }
+                            ]
+                        },
+                        {
+                            "location": "file:///hps/nobackup/proteomics/conversion_comparison/iPRG2015/JD_06232014_sample1_B.mzML",
+                            "name": "JD_06232014_sample1_B",
+                            "fileFormat": {
+                                "cvRef": "MS",
+                                "accession": "MS:1000584",
+                                "name": "mzML format"
+                            },
+                            "fileProperties": [
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000569",
+                                    "name": "SHA-1",
+                                    "value": "8efe8d4e568e79b62fd25cad50a1ec4127dc1996"
+                                },
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000747",
+                                    "name": "completion time",
+                                    "value": "2017-12-18+15:13"
+                                }
+                            ]
+                        },
+                        {
+                            "location": "file:///hps/nobackup/proteomics/conversion_comparison/iPRG2015/JD_06232014_sample1_C.mzML",
+                            "name": "JD_06232014_sample1_C",
+                            "fileFormat": {
+                                "cvRef": "MS",
+                                "accession": "MS:1000584",
+                                "name": "mzML format"
+                            },
+                            "fileProperties": [
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000569",
+                                    "name": "SHA-1",
+                                    "value": "acb9e0f8c3cc93de10637e594d5f2299191b0b9e"
+                                },
+                                {
+                                    "cvRef": "MS",
+                                    "accession": "MS:1000747",
+                                    "name": "completion time",
+                                    "value": "2017-12-18+15:17"
+                                }
+                            ]
+                        }
+                    ],
+                    "analysisSoftware": [
+                        {
+                            "cvRef": "MS",
+                            "accession": "MS:1000752",
+                            "name": "TOPP software",
+                            "version": "2.4.0",
+                            "uri": "http://OpenMS.de/"
+                        }
+                    ]
+                },
+                "qualityParameters": [
+                    {
+                        "cvRef": "STATO",
+                        "accession": "STATO:0000132",
+                        "name": "Hotelling T2 distribution",
+                        "unit": {
+                            "cvRef": "STATO",
+                            "accession": "STATO:0000039",
+                            "name": "statistic"
+                        },
+                        "value": {
+                            "JD_06232014_sample1_A": 0.0182,
+                            "JD_06232014_sample1_B": 0.8567,
+                            "JD_06232014_sample1_C": 1.125
+                        }
+                    }
+                ]
+            }
+        ],
+        "cv": {
+            "QC": {
+                "name": "Proteomics Standards Initiative Quality Control Ontology",
+                "version": "0.1.0",
+                "uri": "https://github.com/HUPO-PSI/qcML-development/blob/master/cv/v0_0_11/qc-cv.obo"
+            },
+            "MS": {
+                "name": "Proteomics Standards Initiative Mass Spectrometry Ontology",
+                "version": "4.1.7",
+                "uri": "https://github.com/HUPO-PSI/psi-ms-CV/blob/master/psi-ms.obo"
+            },
+            "UO": {
+                "name": "Unit Ontology",
+                "version": "09:04:2014 13:37",
+                "uri": "https://github.com/bio-ontology-research-group/unit-ontology/blob/master/unit.obo"
+            },
+            "STATO": {
+                "name": "STATO: the statistical methods ontology",
+                "version": "RC1.4",
+                "uri": "http://purl.obolibrary.org/obo/stato.owl"
+            }
+        }
+    }
+}

--- a/schema/v0_0_11/mzqc_0_0_11.schema.json
+++ b/schema/v0_0_11/mzqc_0_0_11.schema.json
@@ -34,7 +34,7 @@
 					"description": "Collection of CV elements.",
 					"type": "object",
 					"patternProperties": {
-						"[A-Z]{2}": {
+						"[A-Z]+": {
 							"$ref": "#/definitions/cv"
 						}
 					},
@@ -85,12 +85,12 @@
 				"cvRef": {
 					"description": "Reference to the CV that contains the parameter definition.",
 					"type": "string",
-					"pattern": "^[A-Z]{2}$"
+					"pattern": "^[A-Z]+$"
 				},
 				"accession": {
 					"description": "Accession number identifying the parameter within its CV.",
 					"type": "string",
-					"pattern": "^[A-Z]{2}:[0-9]{7}$"
+					"pattern": "^[A-Z]+:[0-9]{7}$"
 				},
 				"name": {
 					"description": "Name of the CV element describing the parameter.",

--- a/schema/v0_0_11/mzqc_0_0_11.schema.json
+++ b/schema/v0_0_11/mzqc_0_0_11.schema.json
@@ -118,18 +118,7 @@
 					"description": "List of input files based on which the QC metrics were generated.",
 					"type": "array",
 					"minItems": 1,
-					"items": [
-						{
-							"type": "object",
-							"properties": {
-								"rawFile": {
-									"description": "Raw spectral file based on which QC metrics were generated.",
-									"$ref": "#/definitions/inputFile"
-								}
-							}
-						}
-					],
-					"additionalItems": {
+					"items": {
 						"$ref": "#/definitions/inputFile"
 					}
 				},

--- a/schema/v0_0_11/mzqc_0_0_11.schema.json
+++ b/schema/v0_0_11/mzqc_0_0_11.schema.json
@@ -5,8 +5,8 @@
 	"description": "JSON schema specifying the mzQC format v0.0.11 developed by the HUPO-PSI Quality Control working group (http://psidev.info/groups/quality-control).",
 	"type": "object",
 	"properties": {
-		"qcML": {
-			"description": "Root qcML element.",
+		"mzQC": {
+			"description": "Root mzQC element.",
 			"type": "object",
 			"properties": {
 				"version": {
@@ -50,7 +50,7 @@
 		}
 	},
 	"additionalProperties": false,
-	"required": ["qcML"],
+	"required": ["mzQC"],
 	"definitions": {
 		"baseQuality": {
 			"description": "Base element describing a runQuality or setQuality.",

--- a/schema/v0_0_11/mzqc_0_0_11.schema.json
+++ b/schema/v0_0_11/mzqc_0_0_11.schema.json
@@ -42,7 +42,7 @@
 				}
 			},
 			"additionalProperties": false,
-			"oneOf": [
+			"anyOf": [
 				{"required": ["runQuality"]},
 				{"required": ["setQuality"]}
 			],

--- a/schema/v0_0_11/mzqc_0_0_11.schema.json
+++ b/schema/v0_0_11/mzqc_0_0_11.schema.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://github.com/HUPO-PSI/qcML-development/tree/master/schema/v0_0_10/mzqc_0_0_10.schema.json",
-	"title": "mzQC schema v0.0.10",
-	"description": "JSON schema specifying the mzQC format v0.0.10 developed by the HUPO-PSI Quality Control working group (http://psidev.info/groups/quality-control).",
+	"$id": "https://github.com/HUPO-PSI/qcML-development/tree/master/schema/v0_0_11/mzqc_0_0_11.schema.json",
+	"title": "mzQC schema v0.0.11",
+	"description": "JSON schema specifying the mzQC format v0.0.11 developed by the HUPO-PSI Quality Control working group (http://psidev.info/groups/quality-control).",
 	"type": "object",
 	"properties": {
 		"qcML": {

--- a/schema/v0_0_11/mzqc_0_0_11.schema.json
+++ b/schema/v0_0_11/mzqc_0_0_11.schema.json
@@ -179,7 +179,7 @@
 				}
 			},
 			"additionalProperties": false,
-			"required": ["location", "fileFormat"]
+			"required": ["location", "name", "fileFormat"]
 		},
 		"qualityParameter": {
 			"description": "Parameter describing a QC metric.",


### PR DESCRIPTION
I created a JSON schema specification to validate mzQC JSON files. Please check it out and let me know if you have any comments.

The JSON schema file is `mzqc_0_0_10.schema.json`. I also adapted Dave's most recent example file `20181005-1091_Pool_start_v0.2.qc.json` so that it's valid against this schema to have an example file.

There are a few remarks I had while creating the JSON schema which should be discussed:

- In the JSON examples we've only included a single `runQuality` so far. In contrast, the XML schema allowed multiple runQualities in a single `qcML` element. Either (1) we add a list of `run`/`setQualities` that can have one or multiple `run`/`setQuality` children, or (2) we allow only a single `run`/`setQuality` per mzQC file. I've used option 1 now, but it adds an extra unnecessary level of indirection if there's only a single `run`/`setQuality`, which will likely be the most prevalent case. Thoughts?

- JSON doesn't really have unique IDs. This informs a few changes and attention points.
    - I have changed the CV list from an actual list of CV elements where the ID is a property of each CV element to a parent element with each CV as property for its ID as key. This makes CV keys unique as properties of an element should be unique (although this is not enforced by all parsers).
    - Unfortunately I haven't been able to figure out how reference to the CVs in the cvParameter elements can be validated, i.e. that those CVs should exist. I don't think this will be possible using JSON schema, so our validator (TBD) should check for this explicitly.
    - Other than for the CVs, as they get referenced by cvParameters, I've omitted the previous ID XML attributes. I'm not sure whether we actually needed those as the name/accession of the qualityParameters can be used to identify the parameters, the IDs were mostly required by XML but not really used by us I think?

- Some small housekeeping changes: consistent element naming (no underscores, camel case), try to use proper JSON instead of XML-inspired JSON.