### PR TITLE
a first go at the OBO...

### DIFF
--- a/cv/v0_1_0/qc-cv.obo
+++ b/cv/v0_1_0/qc-cv.obo
@@ -146,15 +146,37 @@ def: "A metric based on a chromatogram" [PSI:QC]
 is_a: QC:4000001 ! QC metric
 
 [Term]
+id: QC:4000023
+name: MS1 metric
+def: "a metric based on MS1 events" [PSI:QC]
+is_a: QC:4000028 ! QC metric
+
+[Term]
+id: QC:4000024
+name: MS2 metric
+def: "a metric based on MS2 events" [PSI:QC]
+is_a: QC:4000028 ! QC metric
+
+[Term]
 id: QC:4000025
 name: ion source metric
 def: "A metric related to events in the ion source" [PSI:QC]
-is_a: QC:4002000 ! MS metric
+is_a: QC:4000028 ! MS metric
 
 [Term]
 id: QC:4000026
 name: environment metric
 def: "A metric related to measurements of the environment/laboratory/room." [PSI:QC]
+is_a: QC:4000001 ! QC metric
+
+[Term]
+id: QC:4000027
+name: sample preparation metric
+is_a: QC:4000001 ! QC metric
+
+[Term]
+id: QC:4000028
+name: MS metric
 is_a: QC:4000001 ! QC metric
 
 [Term]
@@ -214,7 +236,7 @@ xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000021 ! retention time metric
-is_a: QC:4002100 ! MS1 metric
+is_a: QC:4000023 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -225,7 +247,7 @@ xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000021 ! retention time metric
-is_a: QC:4002200 ! MS2 metric
+is_a: QC:4000024 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -235,7 +257,7 @@ def: "The log ratio for the second to n-th quantile of TIC changes over first qu
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000022 ! chromatogram metric
-is_a: QC:4002100 ! MS1 metric
+is_a: QC:4000023 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -245,7 +267,7 @@ def: "The log ratio for the second to n-th quantile of TIC over first quantile o
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000022 ! chromatogram metric
-is_a: QC:4002100 ! MS1 metric
+is_a: QC:4000023 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -254,7 +276,7 @@ name: MS1 count
 def: "The number of MS1 events in the run." [PSI:QC]
 is_a: QC:4000003 ! single value
 is_a: QC:4000010 ! ID free
-is_a: QC:4002100 ! MS1 metric
+is_a: QC:4000023 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -263,7 +285,7 @@ name: MS2 count
 def: "The number of MS2 events in the run." [PSI:QC]
 is_a: QC:4000003 ! single value
 is_a: QC:4000010 ! ID free
-is_a: QC:4002100 ! MS1 metric
+is_a: QC:4000023 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -272,7 +294,7 @@ name: Maximal MS2 frequency
 def: "The fastest frequency for MS/MS collection in any minute over the complete run" [PSI:QC]
 is_a: QC:4000003 ! single value
 is_a: QC:4000010 ! ID free
-is_a: QC:4002200 ! MS2 metric
+is_a: QC:4000024 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -282,7 +304,7 @@ def: "The first to n-th quantile of MS2 scan peak counts. The cvParam value defi
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
-is_a: QC:4002200 ! MS2 metric
+is_a: QC:4000024 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -293,7 +315,7 @@ xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000005 ! corresponding lists
 is_a: QC:4000010 ! ID free
 is_a: QC:4000025 ! ion source metric
-is_a: QC:4002200 ! MS2 metric
+is_a: QC:4000024 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -304,7 +326,7 @@ xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000005 ! corresponding lists
 is_a: QC:4000010 ! ID free
 is_a: QC:4000025 ! ion source metric
-is_a: QC:4002200 ! MS2 metric
+is_a: QC:4000024 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -314,7 +336,7 @@ def: "Median m/z value for all identified peptides (unique ions) after FDR." [PS
 is_a: QC:4000003 ! single value
 is_a: QC:4000009 ! ID based
 is_a: QC:4000025 ! ion source metric
-is_a: QC:4002100 ! MS1 metric
+is_a: QC:4000023 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -324,8 +346,8 @@ def: "Fraction of total MS2 scans identified after FDR in the respective quantil
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000009 ! ID based
-is_a: QC:4002100 ! MS1 metric
-is_a: QC:4002200 ! MS2 metric
+is_a: QC:4000023 ! MS1 metric
+is_a: QC:4000024 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -352,23 +374,6 @@ relationship: has_relation QC:4000013 ! QC metric relation: one run
 id: QC:4001000
 name: sample preparation metric
 is_a: QC:4000001 ! QC metric
-
-[Term]
-id: QC:4002000
-name: MS metric
-is_a: QC:4000001 ! QC metric
-
-[Term]
-id: QC:4002100
-name: MS1 metric
-def: "a metric based on MS1 events" [PSI:QC]
-is_a: QC:4002000 ! MS metric
-
-[Term]
-id: QC:4002200
-name: MS2 metric
-def: "a metric based on MS2 events" [PSI:QC]
-is_a: QC:4002000 ! MS metric
 
 [Typedef]
 id: has_relation

--- a/cv/v0_1_0/qc-cv.obo
+++ b/cv/v0_1_0/qc-cv.obo
@@ -2,23 +2,23 @@ format-version: 1.2
 data-version: 0.1.0
 date: 27:09:2018 16:05
 saved-by: julianu
-import: http://ontologies.berkeleybop.org/uo.obo
-import: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo
-import: https://raw.githubusercontent.com/HUPO-PSI/qcML-development/master/cv/qc-cv-legacy-0.0.8.obo
 default-namespace: QC
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
 namespace-id-rule: * QC:$sequence(7,0,9999999)$
+remark: coverage: Mass spectrometer quality control metrics
+remark: creator: Chris Bielow <chris.bielow <-at-> fu-berlin.de>
+remark: creator: Julian Uszkoreit <julian.uszkoreit <-at-> ruhr-uni-bochum.de>
+remark: creator: Martin Eisenacher <martin.eisenacher <-at-> ruhr-uni-bochum.de>
 remark: namespace: MS
 remark: namespace: QC
-remark: coverage: Mass spectrometer quality control metrics
-remark: creator: Martin Eisenacher <martin.eisenacher <-at-> ruhr-uni-bochum.de>
-remark: creator: Julian Uszkoreit <julian.uszkoreit <-at-> ruhr-uni-bochum.de>
+import: http://ontologies.berkeleybop.org/uo.obo
+import: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo
 ontology: qc
 
 [Term]
 id: MS:1009001
 name: quality control metrics generating software
-def: "Quality control metrics generating softwares are special types of analysis softwares, which are capable to generate QC metrics." [PSI:PI]
+def: "Quality control metrics generating softwares are special types of analysis softwares, which are capable of generating QC metrics." [PSI:PI]
 is_a: MS:1001456 ! analysis software
 
 [Term]
@@ -41,12 +41,12 @@ def: "Parent term for QC metrics, each metric MUST have this as an ancestor in i
 [Term]
 id: QC:4000002
 name: QC metric type
-def: "the QC metric type describes what type the respective metric is, like e.g. single value, n-tuple or table" [PSI:QC]
+def: "The QC metric type describes what type the respective metric is, like e.g. single value, n-tuple or table" [PSI:QC]
 
 [Term]
 id: QC:4000003
 name: single value
-def: "metrics consisting of a single value (in contrast to n-tuple or table)." [PSI:QC]
+def: "Metrics consisting of a single value (in contrast to n-tuple or table)." [PSI:QC]
 is_a: QC:4000002 ! QC metric type
 
 [Term]
@@ -66,7 +66,7 @@ is_a: QC:4000002 ! QC metric type
 [Term]
 id: QC:4000006
 name: table
-def: "metrics consisting of a table or data frame (in contrast to single_value or n-tuple), the values of the table may have different types in each column (in contrast to a matrix). The actual structure of the matrix is defined in the QC document." [PSI:QC]
+def: "Metrics consisting of a table or data frame (in contrast to single_value or n-tuple), the values of the table may have different types in each column (in contrast to a matrix). The actual structure of the matrix is defined in the QC document." [PSI:QC]
 is_a: QC:4000002 ! QC metric type
 
 [Term]
@@ -83,19 +83,19 @@ def: "The basis for this QC metric, like ID based, ID free, quant based..." [PSI
 [Term]
 id: QC:4000009
 name: ID based
-def: "metrics based on a previous identification run (in contrast to ID_free, Quant_based)" [PSI:QC]
+def: "Metrics based on a previous identification run (in contrast to ID_free, Quant_based)" [PSI:QC]
 is_a: QC:4000008 ! QC metric basis
 
 [Term]
 id: QC:4000010
 name: ID free
-def: "metrics not based on a previous identification run (in contrast to ID_based, quant_based)" [PSI:QC]
+def: "Metrics not based on a previous identification run (in contrast to ID_based, quant_based)" [PSI:QC]
 is_a: QC:4000008 ! QC metric basis
 
 [Term]
 id: QC:4000011
-name: Quantification based
-def: "metrics based on a previous quantification run (in contrast to ID_free, ID_based)" [PSI:QC]
+name: quantification based
+def: "Metrics based on a previous quantification run (in contrast to ID_free, ID_based)" [PSI:QC]
 is_a: QC:4000008 ! QC metric basis
 
 [Term]
@@ -106,67 +106,55 @@ def: "A QC metric describes the basis for the metric calculation like \"one MS r
 [Term]
 id: QC:4000013
 name: QC metric relation: one run
-def: "describes a metric which is calculated on one run (e.g. one .raw file)" [PSI:QC]
+def: "Describes a metric which is calculated on one run (e.g. one .raw file)" [PSI:QC]
 is_a: QC:4000012 ! QC metric relation
 
 [Term]
 id: QC:4000014
 name: QC metric relation: multiple runs
-def: "a metric which is calculated on multiple runs / a set of runs (e.g. multiple .raw files)" [PSI:QC]
+def: "A metric which is calculated on multiple runs / a set of runs (e.g. multiple .raw files)" [PSI:QC]
 is_a: QC:4000012 ! QC metric relation
 
 [Term]
 id: QC:4000015
 name: QC metric relation: one spectrum
-def: "a metric which is calculated on one spectrum" [PSI:QC]
+def: "A metric which is calculated on one spectrum" [PSI:QC]
 is_a: QC:4000012 ! QC metric relation
 
 [Term]
 id: QC:4000016
 name: QC metric relation: multiple spectra
-def: "a metric which is calculated on multiple spectra" [PSI:QC]
+def: "A metric which is calculated on multiple spectra" [PSI:QC]
 is_a: QC:4000012 ! QC metric relation
 
 [Term]
 id: QC:4000020
 name: XIC metric
-def: "a metric based on extracted ion chromatograms" [PSI:QC]
+def: "A metric based on extracted ion chromatograms" [PSI:QC]
 is_a: QC:4000022 ! chromatogram metric
 
 [Term]
 id: QC:4000021
 name: retention time metric
-def: "a metric based on the retention time" [PSI:QC]
+def: "A metric based on retention time" [PSI:QC]
 is_a: QC:4000001 ! QC metric
 
 [Term]
 id: QC:4000022
 name: chromatogram metric
-def: "a metric based on the chromatogram" [PSI:QC]
-is_a: QC:4000001 ! QC metric
-
-[Term]
-id: QC:4000023
-name: MS1 metric
-def: "a metric based on MS1 events" [PSI:QC]
-is_a: QC:4000001 ! QC metric
-
-[Term]
-id: QC:4000024
-name: MS2 metric
-def: "a metric based on MS2 events" [PSI:QC]
+def: "A metric based on a chromatogram" [PSI:QC]
 is_a: QC:4000001 ! QC metric
 
 [Term]
 id: QC:4000025
 name: ion source metric
-def: "a metric related to events in the ions source" [PSI:QC]
-is_a: QC:4000001 ! QC metric
+def: "A metric related to events in the ion source" [PSI:QC]
+is_a: QC:4002000 ! MS metric
 
 [Term]
 id: QC:4000026
 name: environment metric
-def: "a metric related to measurements of the environment" [PSI:QC]
+def: "A metric related to measurements of the environment/laboratory/room." [PSI:QC]
 is_a: QC:4000001 ! QC metric
 
 [Term]
@@ -181,7 +169,7 @@ relationship: has_relation QC:4000013 ! QC metric relation: one run
 [Term]
 id: QC:4000051
 name: XIC-FWHM quantiles
-def: "The first to n-th quantile of peak widths for the wide XICs. The cvParam value defines the number of given quantiles n." [PSI:QC]
+def: "The first to n-th quantile of peak widths for the wide XICs. The cvParam value defines the number of given quantiles 'n'." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
@@ -191,7 +179,7 @@ relationship: has_relation QC:4000013 ! QC metric relation: one run
 [Term]
 id: QC:4000052
 name: XIC-Height quantiles ratio to Q1
-def: "The log ratio for second to n-th quantile of wide XIC heights over first quantile of heights. The cvParam value defines the number of given quantiles n (the corresponding tuple of the metric has n-1 values)." [PSI:QC]
+def: "The log ratio for the second to n-th quantile of wide XIC heights over first quantile of heights. The cvParam value defines the number of given quantiles 'n' (the corresponding tuple of the metric has n-1 values)." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
@@ -210,7 +198,7 @@ relationship: has_relation QC:4000013 ! QC metric relation: one run
 [Term]
 id: QC:4000054
 name: RT of TIC quantile
-def: "The interval when the respective quantile of the TIC accumulates divided by retention time duration. The number of quantiles n is is defined by the cvParam value." [PSI:QC]
+def: "The interval when the respective quantile of the TIC accumulates divided by retention time duration. The number of quantiles 'n' is is defined by the cvParam value." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
@@ -221,43 +209,43 @@ relationship: has_relation QC:4000013 ! QC metric relation: one run
 [Term]
 id: QC:4000055
 name: MS1 quantiles RT fraction
-def: "The interval for the first to n-th quantile of all MS1 events divided by RT-Duration. The number of quantiles n is is defined by the cvParam value." [PSI:QC]
+def: "The interval for the first to n-th quantile of all MS1 events divided by RT-Duration. The number of quantiles 'n' is is defined by the cvParam value." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000021 ! retention time metric
-is_a: QC:4000023 ! MS1 metric
+is_a: QC:4002100 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000056
 name: MS2 quantiles RT fraction
-def: "The interval for the first to n-th quantile of all MS2 events divided by RT-Duration. The number of quantiles n is is defined by the cvParam value." [PSI:QC]
+def: "The interval for the first to n-th quantile of all MS2 events divided by RT-Duration. The number of quantiles 'n' is is defined by the cvParam value." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000021 ! retention time metric
-is_a: QC:4000024 ! MS2 metric
+is_a: QC:4002200 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000057
 name: MS1 quantile TIC change ratio to Q1
-def: "The log ratio for the second to n-th quantile of TIC changes over first quantile of TIC changes. The cvParam value defines the number of given quantiles n (the corresponding tuple of the metric has n-1 values)." [PSI:QC]
+def: "The log ratio for the second to n-th quantile of TIC changes over first quantile of TIC changes. The cvParam value defines the number of given quantiles 'n' (the corresponding tuple of the metric has n-1 values)." [PSI:QC]
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000022 ! chromatogram metric
-is_a: QC:4000023 ! MS1 metric
+is_a: QC:4002100 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000058
 name: MS1 quantile TIC ratio to Q1
-def: "The log ratio for the second to n-th quantile of TIC over first quantile of TIC. The cvParam value defines the number of given quantiles n (the corresponding tuple of the metric has n-1 values)." [PSI:QC]
+def: "The log ratio for the second to n-th quantile of TIC over first quantile of TIC. The cvParam value defines the number of given quantiles 'n' (the corresponding tuple of the metric has n-1 values)." [PSI:QC]
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
 is_a: QC:4000022 ! chromatogram metric
-is_a: QC:4000023 ! MS1 metric
+is_a: QC:4002100 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -266,7 +254,7 @@ name: MS1 count
 def: "The number of MS1 events in the run." [PSI:QC]
 is_a: QC:4000003 ! single value
 is_a: QC:4000010 ! ID free
-is_a: QC:4000023 ! MS1 metric
+is_a: QC:4002100 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -275,26 +263,26 @@ name: MS2 count
 def: "The number of MS2 events in the run." [PSI:QC]
 is_a: QC:4000003 ! single value
 is_a: QC:4000010 ! ID free
-is_a: QC:4000023 ! MS1 metric
+is_a: QC:4002100 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000061
-name: maximal MS2 frequency
+name: Maximal MS2 frequency
 def: "The fastest frequency for MS/MS collection in any minute over the complete run" [PSI:QC]
 is_a: QC:4000003 ! single value
 is_a: QC:4000010 ! ID free
-is_a: QC:4000024 ! MS2 metric
+is_a: QC:4002200 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000062
 name: MS2 density per quantile
-def: "The was the first to n-th quantile of MS2 scan peak counts. The cvParam value defines the number of given quantiles n." [PSI:QC]
+def: "The first to n-th quantile of MS2 scan peak counts. The cvParam value defines the number of given quantiles 'n'." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000010 ! ID free
-is_a: QC:4000024 ! MS2 metric
+is_a: QC:4002200 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
@@ -304,46 +292,46 @@ def: "The fraction of MS/MS precursors of the corresponding charge. The fraction
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000005 ! corresponding lists
 is_a: QC:4000010 ! ID free
-is_a: QC:4000024 ! MS2 metric
 is_a: QC:4000025 ! ion source metric
+is_a: QC:4002200 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000064
 name: MS2 unknown and likely precursor charges fractions
-def: "The fraction of MS/MS precursors of unknown, but possible likely charges. The fractions are given in the first list, the likely charges in the second list, charge 0 stands for unknown. The cvParam value defines the number of entries in both lists." [PSI:QC]
+def: "The fractions of inferred charge state of MS/MS precursors. The fractions [0,1] are given in the first list, their charges in the second list. Charge 0 stands for unknown. The cvParam value defines the number of entries in both lists. The sum of fractions must sum to 1." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000005 ! corresponding lists
 is_a: QC:4000010 ! ID free
-is_a: QC:4000024 ! MS2 metric
 is_a: QC:4000025 ! ion source metric
+is_a: QC:4002200 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000065
 name: Precursor median m/z for IDs
-def: "Median m/z value for all identified peptides (unique ions)." [PSI:QC]
+def: "Median m/z value for all identified peptides (unique ions) after FDR." [PSI:QC]
 is_a: QC:4000003 ! single value
 is_a: QC:4000009 ! ID based
-is_a: QC:4000023 ! MS1 metric
 is_a: QC:4000025 ! ion source metric
+is_a: QC:4002100 ! MS1 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000066
 name: Fraction of MS2 identified at different MS1 quantiles
-def: "Fraction of total MS2 scans identified in the respective quantile of peptides sorted by MS1 maximum intensity. The cvParam value defines the number of given quantiles n." [PSI:QC]
+def: "Fraction of total MS2 scans identified after FDR in the respective quantile of peptides sorted by MS1 maximum intensity. The cvParam value defines the number of given quantiles 'n'." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000004 ! n-tuple
 is_a: QC:4000009 ! ID based
-is_a: QC:4000023 ! MS1 metric
-is_a: QC:4000024 ! MS2 metric
+is_a: QC:4002100 ! MS1 metric
+is_a: QC:4002200 ! MS2 metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
 [Term]
 id: QC:4000067
 name: Total ion current chromatogram
-def: "The (centroided) total ion current chromatogram. The first list contains the m/z values, the second list the corresponding abundancies. The cvParam value defines the number of entries in both lists." [PSI:QC]
+def: "The (centroided) total ion current chromatogram. The first list contains the m/z values, the second list the corresponding abundances. The cvParam value defines the number of entries in both lists." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: QC:4000005 ! corresponding lists
 is_a: QC:4000010 ! ID free
@@ -353,12 +341,34 @@ relationship: has_relation QC:4000013 ! QC metric relation: one run
 [Term]
 id: QC:4000068
 name: Ambient humidity
-def: "The Ambient humidity. The cvParam value defines the number of values. TODO: why is this an n-tuple?" [PSI:QC]
+def: "The ambient relative humidity in percent (0,100) over one or more time points. The cvParam value defines the number of values. The first list contains is the ambient humidity value(s). The second contains the respective retention time. A negative RT implies that the exact time of measurement is unknown." [PSI:QC]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: QC:4000004 ! n-tuple
+is_a: QC:4000005 ! corresponding lists
 is_a: QC:4000010 ! ID free
 is_a: QC:4000026 ! environment metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
+
+[Term]
+id: QC:4001000
+name: sample preparation metric
+is_a: QC:4000001 ! QC metric
+
+[Term]
+id: QC:4002000
+name: MS metric
+is_a: QC:4000001 ! QC metric
+
+[Term]
+id: QC:4002100
+name: MS1 metric
+def: "a metric based on MS1 events" [PSI:QC]
+is_a: QC:4002000 ! MS metric
+
+[Term]
+id: QC:4002200
+name: MS2 metric
+def: "a metric based on MS2 events" [PSI:QC]
+is_a: QC:4002000 ! MS metric
 
 [Typedef]
 id: has_relation
@@ -371,3 +381,4 @@ name: has_type
 [Typedef]
 id: has_units
 name: has_units
+

--- a/cv/v0_1_0/qc-cv.obo
+++ b/cv/v0_1_0/qc-cv.obo
@@ -370,11 +370,6 @@ is_a: QC:4000010 ! ID free
 is_a: QC:4000026 ! environment metric
 relationship: has_relation QC:4000013 ! QC metric relation: one run
 
-[Term]
-id: QC:4001000
-name: sample preparation metric
-is_a: QC:4000001 ! QC metric
-
 [Typedef]
 id: has_relation
 name: has_relation


### PR DESCRIPTION
changes to be discussed:

I have made some changes to the OBO structure, in particular:
 - added `sample preparation metric` as child to QC metric
 - added `MS metric` as layer between `QC metric` and `MS1 metric` (same for MS2)
 - started changing some IDs:
    - the idea is that the IDs somewhat reflect the tree/graph structure, such that a knowledgable user ca n infer that `QC:4001????` must be a some sort of RT metric... not sure of this is a) allowed b) agreeable
 - the `ambient humidity` had a TODO (why n-tuple #64 ). I just came up with something completely different (corresponding lists), hoping that this would make sense. To be discussed I guess :)
 - some minor typos and low/uppercase fixes to make everything a bit more uniform
 - I removed (out of ignorance) the qc-cv-legacy-0.0.8.obo. Why was that present? It seems to me it should not carry over... Can someone enlighten me :)

I'll open up another issue with related questions...
PTXQC metrics are next on my list. Coming soon...

note: my `Protege` editor reorders some lines automagically. I hope thats ok...