### PR TITLE
packaged ID-free metrics from QuaMeter for a first PR into MS-CV

### DIFF
--- a/cv/qc-cv.obo
+++ b/cv/qc-cv.obo
@@ -1,13 +1,14 @@
 format-version: 1.2
 data-version: 0.1.5
-date: 10:11:2021 14:03
+date: 09:12:2021 12:03
 saved-by: Mathias Walzer
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
 remark: coverage of namespace-id: MS:$sequence(7,4000000,4999999)$: Mass spectrometry quality control metrics
 remark: creator: Chris Bielow <chris.bielow <-at-> fu-berlin.de>
+remark: creator: Wout Bittremieux <wbittremieux <-at-> health.ucsd.edu>
+remark: creator: Nils Hoffmann < nils.hoffmann <-at-> cebitec.uni-bielefeld.de>
 remark: creator: Julian Uszkoreit <julian.uszkoreit <-at-> ruhr-uni-bochum.de>
-remark: creator: Martin Eisenacher <martin.eisenacher <-at-> ruhr-uni-bochum.de>
 remark: creator: Mathias Walzer <walzer <-at-> ebi.ac.uk>
 remark: namespace: MS
 import: http://ontologies.berkeleybop.org/uo.obo
@@ -15,6 +16,7 @@ import: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo
 import: https://raw.githubusercontent.com/obi-ontology/obi/master/obi.owl
 import: https://raw.githubusercontent.com/ISA-tools/stato/dev/releases/1.4/stato.obo
 ontology: ms
+
 
 [Typedef]
 id: has_relation
@@ -25,6 +27,14 @@ id: has_type
 name: has_type
 
 [Typedef]
+id: has_units
+name: has_units
+
+[Typedef]
+id: has_value_concept
+name: has_value_concept
+
+[Typedef]
 id: has_column
 name: has_column
 
@@ -32,9 +42,6 @@ name: has_column
 id: has_optional_column
 name: has_optional_column
 
-[Typedef]
-id: has_units
-name: has_units
 
 
 [Term]
@@ -105,12 +112,6 @@ id: MS:4000011
 name: quantification based
 def: "QC metric based on quantification results." [PSI:QC]
 is_a: MS:4000008 ! QC metric category
-
-[Term]
-id: MS:4000012
-name: QC metric relation DEPRECATED
-def: "The basis for the metric calculation, such as 'single run' or 'single spectrum'." [PSI:QC]
-relationship: part_of MS:4000000 ! PSI-MS CV Quality Control Vocabulary
 
 [Term]
 id: MS:4000013
@@ -190,1963 +191,257 @@ name: MS metric
 def: "QC metric related to the mass spectrometry acquisition." [PSI:QC]
 is_a: MS:4000001 ! QC metric
 
+
 [Term]
 id: MS:4000050
 name: XIC-WideFrac
 def: "The fraction of precursor ions accounting for the top half of all peak widths" [PSI:QC]
+comment: No synonym for QuaMeter names since this is literally the QuaMeter metric
+comment: is it precursor ions accounting for the top 50% of all precursor ion peaks' FWHM?,  
 is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000020 ! XIC metric
-relationship: has_relation MS:4000013 ! single run based
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_units UO:0000191 ! fraction
 
 [Term]
 id: MS:4000051
 name: XIC-FWHM quantiles
 def: "The first to n-th quantile of peak widths for the wide XICs." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000020 ! XIC metric
-relationship: has_relation MS:1000086 ! full width at half-maximum
-relationship: has_relation MS:4000013 ! single run based
+comment: No idea what wide XICs are...
 synonym: "XIC-FWHM-Q1" RELATED []
 synonym: "XIC-FWHM-Q2" RELATED []
 synonym: "XIC-FWHM-Q3" RELATED []
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000020 ! XIC metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_concept STATO:0000291 ! quantile
+relationship: has_value_concept MS:1000086 ! full width at half-maximum
+relationship: has_units UO:0000010 ! second
 
 [Term]
 id: MS:4000052
 name: XIC-Height quantiles ratio to Q1
 def: "The log ratio for the second to n-th quantile of wide XIC heights over previous quantile of heights. For the boundary elements min/max are used." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000020 ! XIC metric
-relationship: has_relation MS:1000042 ! peak intensity
-relationship: has_relation MS:1000627 ! selected ion current chromatogram
-relationship: has_relation MS:4000013 ! single run based
 synonym: "XIC-Height-Q2" RELATED []
 synonym: "XIC-Height-Q3" RELATED []
 synonym: "XIC-Height-Q4" RELATED []
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000020 ! XIC metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_concept STATO:0000105 ! log signal intensity ratio
+relationship: has_units UO:0000191 ! fraction
 
 [Term]
 id: MS:4000053
 name: RT duration
-def: "The retention time duration of the MS run in seconds, similar to the highest scan time minus the lowest scan time." [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000021 ! retention time metric
-relationship: has_relation MS:1000016 ! scan start time
-relationship: has_relation MS:4000013 ! single run based
+def: "The retention time duration of the MS run in seconds." [PSI:QC]
+comment: This was also part of the Quameter manual's definition - ... , similar to the highest scan time minus the lowest scan time.
+comment: no synonym as the name matches exact
 synonym: "RT-Duration" EXACT []
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000021 ! retention time metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_concept NCIT:C25330 ! Duration
+relationship: has_units UO:0000010 ! second
 
 [Term]
 id: MS:4000054
 name: RT over TIC quantile
 def: "The interval when the respective quantile of the TIC accumulates divided by retention time duration. The number of quantiles observed is given by the size of the tuple." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000021 ! retention time metric
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000235 ! total ion current chromatogram
-relationship: has_relation MS:4000013 ! single run based
 synonym: "RT-TIC-Q1" RELATED []
 synonym: "RT-TIC-Q2" RELATED []
 synonym: "RT-TIC-Q3" RELATED []
 synonym: "RT-TIC-Q4" RELATED []
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000021 ! retention time metric
+relationship: has_metric_category MS:4000022 ! chromatogram metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000191 ! fraction
 
 [Term]
 id: MS:4000055
 name: MS1 quantiles RT fraction
 def: "The interval used for acquisition of the first, second, third, and fourth quarter of all MS1 events divided by RT-Duration." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000021 ! retention time metric
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:1000016 ! scan start time
-relationship: has_relation MS:1000579 ! MS1 spectrum
-relationship: has_relation MS:4000013 ! single run based
 synonym: "RT-MS-Q1" RELATED []
 synonym: "RT-MS-Q2" RELATED []
 synonym: "RT-MS-Q3" RELATED []
 synonym: "RT-MS-Q4" RELATED []
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000021 ! retention time metric
+relationship: has_metric_category MS:4000023 ! MS1 metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000191 ! fraction
 
 [Term]
 id: MS:4000056
 name: MS2 quantiles RT fraction
 def: "The interval used for acquisition of the first, second, third, and fourth quarter of all MS2 events divided by RT-Duration." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000021 ! retention time metric
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:1000016 ! scan start time
-relationship: has_relation MS:1000580 ! MSn spectrum
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_units UO:0000191 ! fraction
 synonym: "RT-MSMS-Q1" RELATED []
 synonym: "RT-MSMS-Q2" RELATED []
 synonym: "RT-MSMS-Q3" RELATED []
 synonym: "RT-MSMS-Q4" RELATED []
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000021 ! retention time metric
+relationship: has_metric_category MS:4000024 ! MS2 metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_units UO:0000191 ! fraction
 
 [Term]
 id: MS:4000057
 name: MS1 quantile TIC change ratio to Q1
 def: "The log ratio for the second to n-th quantile of TIC changes over first quantile of TIC changes." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:1000016 ! scan start time
-relationship: has_relation MS:1000235 ! total ion current chromatogram
-relationship: has_relation MS:4000013 ! single run based
+comment: this definition is not implementation clear
 synonym: "MS1-TIC-Change-Q2" RELATED []
 synonym: "MS1-TIC-Change-Q3" RELATED []
 synonym: "MS1-TIC-Change-Q4" RELATED []
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000022 ! chromatogram metric
+relationship: has_metric_category MS:4000023 ! MS1 metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_concept STATO:0000105 ! log signal intensity ratio
 
 [Term]
 id: MS:4000058
 name: MS1 quantile TIC ratio to Q1
 def: "The log ratio for the second to n-th quantile of TIC over the previous quantile of TIC. For the boundary elements min/max are used." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:1000016 ! scan start time
-relationship: has_relation MS:1000235 ! total ion current chromatogram
-relationship: has_relation MS:4000013 ! single run based
 synonym: "MS1-TIC-Q2" RELATED []
 synonym: "MS1-TIC-Q3" RELATED []
 synonym: "MS1-TIC-Q4" RELATED []
+is_a: MS:4000004 ! n-tuple
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000022 ! chromatogram metric
+relationship: has_metric_category MS:4000023 ! MS1 metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_value_concept STATO:0000105 ! log signal intensity ratio
 
 [Term]
 id: MS:4000059
 name: Number of MS1 spectra
 def: "The number of MS1 events in the run." [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000023 ! MS1 metric
 comment: A lower number of MS1 spectra acquired during one sample run compared to similar runs can indicate mismatched instrument settings or issues with the instrumentation or issues with sample amounts.
-relationship: has_relation MS:1000579 ! MS1 spectrum
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_units UO:0000189 ! count unit
 synonym: "MS1-Count" EXACT []
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000023 ! MS1 metric
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000060
 name: Number of MS2 spectra
 def: "The number of MS2 events in the run." [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
 comment: A lower number of MS2 spectra acquired during one sample run compared to similar runs can indicate mismatched instrument settings or issues with the instrumentation or unusual low levels of ions collectable for MS/MS.
-relationship: has_relation MS:1000580 ! MSn spectrum
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_units UO:0000189 ! count unit
 synonym: "MS2-Count" EXACT []
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000024 ! MS2 metric
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000062
 name: MS2 density per quantile
 def: "The first to n-th quantile of MS2 scan peak counts." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:1000035 ! peak picking
-relationship: has_relation MS:4000013 ! single run based
+comment: the name implies the density of something in quantiles of another thing (so quarters would be more appropriate), but I think the definition intention is to divide the range of MS" densities and report the quantiles?
 synonym: "MS2-Density-Q1" RELATED []
 synonym: "MS2-Density-Q2" RELATED []
 synonym: "MS2-Density-Q3" RELATED []
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000024 ! MS2 metric
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
+relationship: has_value_concept NCIT:C45781 ! Density
+relationship: has_units UO:0000189 ! count unit
 
 [Term]
 id: MS:4000063
 name: MS2 known precursor charges fractions
-def: "The fraction of MS/MS precursors of the corresponding charge. The fractions [0,1] are given in the 'Fraction' column, corresponding charges in the 'Charge state' column. The highest charge state is to be interpreted as that charge state or higher. " [PSI:QC]
-is_a: MS:4000006 ! table
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-is_a: MS:4000025 ! ion source metric
-relationship: has_relation MS:1000041 ! charge state
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_column: MS:4000238 ! Charge state
-relationship: has_column: MS:4000239 ! Fraction
+def: "The fraction of MS/MS precursors of the corresponding charge. The fractions [0,1] are given in the 'Fraction' column, corresponding charges in the 'Charge state' column. The highest charge state is to be interpreted as that charge state or higher." [PSI:QC]
 synonym: "MS2-PrecZ-1" RELATED []
 synonym: "MS2-PrecZ-2" RELATED []
 synonym: "MS2-PrecZ-3" RELATED []
 synonym: "MS2-PrecZ-4" RELATED []
 synonym: "MS2-PrecZ-5" RELATED []
 synonym: "MS2-PrecZ-more" RELATED []
+is_a: MS:4000006 ! table
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000024 ! MS2 metric
+relationship: has_metric_category MS:4000025 ! ion source metric
+relationship: has_column: MS:4000238 ! Charge state column
+relationship: has_column: MS:4000239 ! Fraction column
 
 [Term]
 id: MS:4000064
 name: MS2 unknown and likely precursor charges fractions
 def: "The fractions of inferred charge state of MS/MS precursors. The fractions [0,1] are given in the 'Fraction' column, corresponding charges in the 'Charge state' column. Charge 0 represents unknown charge states." [PSI:QC]
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-is_a: MS:4000025 ! ion source metric
-is_a: MS:4000006 ! table
-relationship: has_relation MS:1000041 ! charge state
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_column: MS:4000238 ! Charge state
-relationship: has_column: MS:4000239 ! Fraction
 synonym: "MS2-PrecZ-likely-1" RELATED []
 synonym: "MS2-PrecZ-likely-multi" RELATED []
-
-[Term]
-id: MS:4000065
-name: Precursor median m/z for IDs
-def: "Median m/z value for all identified peptides (unique ions) after FDR." [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000023 ! MS1 metric
-is_a: MS:4000025 ! ion source metric
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000066
-name: Fraction of MS2 identified at different MS1 quantiles
-def: "Fraction of total MS2 scans identified after FDR in the respective quantile of peptides sorted by MS1 maximum intensity." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000009 ! ID based
-is_a: MS:4000023 ! MS1 metric
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000067
-name: Total ion current chromatogram table
-def: "The total ion current chromatogram. The first column contains the retention time values in second, the second column the corresponding relative intensities." [PSI:QC]
 is_a: MS:4000006 ! table
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000235 ! total ion current chromatogram
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_column: MS:4000108 ! Retention time
-relationship: has_column: MS:4000109 ! Relative intensity
-
-[Term]
-id: MS:4000068
-name: Ambient humidity
-def: "The ambient relative humidity in percent (0,100) over one or more time points. The first column contains is the ambient humidity value(s). The second contains the respective retention time. A negative RT implies that the exact time of measurement is unknown." [PSI:QC]
-is_a: MS:4000006 ! table
-is_a: MS:4000010 ! ID free
-is_a: MS:4000026 ! environment metric
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_column: MS:4000108 ! Retention time
-relationship: has_column: MS:4000260 ! Percent
-
-[Term]
-id: MS:4000069
-name: MS1 Total ion current chromatogram
-def: "The total ion current chromatogram of MS1 measurements. The first column contains the retention time values in seconds, the second column the corresponding relative intensities." [PSI:QC]
-comment: The metric enables to check visually e.g. MS1 TIC stability along the retention time and its absolute value compared to MS2 total ion chromatogram or other analyses MS1 TICs. TIC drops caused by e.g. spray stability issues or bubbles presence can be detected here.
-is_a: MS:4000006 ! table
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_relation MS:4000067 ! Total ion current chromatogram
-relationship: has_column: MS:4000108 ! Retention time
-relationship: has_column: MS:4000109 ! Relative intensity
-
-[Term]
-id: MS:4000070
-name: MS2 Total ion current chromatogram
-def: "The total ion current chromatogram of MS2 measurements. The first column contains the retention time values in second, the second column the corresponding relative intensities." [PSI:QC]
-comment: The metric enables to check visually e.g. MS2 TIC absolute value compared to MS1 total ion chromatogram or other analyses MS2 TICs.
-is_a: MS:4000006 ! table
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_relation MS:4000067 ! Total ion current chromatogram
-relationship: has_column: MS:4000108 ! Retention time
-relationship: has_column: MS:4000109 ! Relative intensity
-
-[Term]
-id: MS:4000071
-name: Fraction of peptide IDs around max MS1
-def: "Fraction of all peptides identified at least X minutes earlier or later than the most intense MS1 signal of the identification. The first column contains the time in minute-wise steps of seconds, the other comlumn the fraction of identified. Negative time values indicate minutes before and positive after maximum MS1." [PSI:QC]
-comment: Estimates very early peak broadening.
-is_a: MS:4000006 ! table
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_column: MS:4000108 ! Retention time
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000024 ! MS2 metric
+relationship: has_metric_category MS:4000025 ! ion source metric
+relationship: has_column: MS:4000238 ! Charge state
 relationship: has_column: MS:4000239 ! Fraction
-
-[Term]
-id: MS:4000072
-name: Interquartile RT period for peptide identifications
-def: "The interquartile retention time period, in seconds, for all peptide identifications over the complete run." [PSI:QC]
-comment: Longer times indicate better chromatographic separation.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000073
-name: Peptide identification rate of the interquartile RT period
-def: "The identification rate of peptides for the interquartile retention time period, in peptides per second." [PSI:QC]
-comment: Higher rates indicate efficient sampling and identification.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_relation MS:4000072 ! Interquartile RT period for peptide identifications
-
-[Term]
-id: MS:4000074
-name: Median MS1 peak FWHM for peptides
-def: "Median of all MS1 peak widths at half maximum (FWHM) for all identified peptides, in seconds" [PSI:QC]
-comment: Sharper peak widths (i.e. smaller values) indicate better chromatographic resolution.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000086 ! full width at half-maximum
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000075
-name: Interquartile distance of MS1 peak FWHM for identifications
-def: "Interquartile distance of all MS1 peak widths at half maximum (FWHM) for all identifications, in seconds" [PSI:QC]
-comment: Tighter distributions indicate better consistency.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000086 ! full width at half-maximum
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000076
-name: Median MS1 peak FWHM for peptides in RT quantile
-def: "Median of all MS1 peak widths at half maximum (FWHM) for all identified peptide, in seconds, in the respective identifications' quantiles ordered by retention time. The data is given in a tuple defining the quantiles, 4-tuple represents quartiles, 10-tuple deciles, etc." [PSI:QC]
-comment: Sharper peak widths (i.e. smaller values) indicate better chromatographic resolution in the given quantile.
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000086 ! full width at half-maximum
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000077
-name: Area under TIC
-def: "The area under the total ion chromatogram." [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000235 ! total ion current chromatogram
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000078
-name: Area under TIC RT quantiles
-def: "The area under the total ion chromatogram of the retention time quantiles. Number of quantiles are given by the n-tuple." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000235 ! total ion current chromatogram
-relationship: has_relation MS:4000013 ! single run based
-
-[Term]
-id: MS:4000079
-name: Pump pressure chromatogram
-def: "Representation of chromatographic pressure versus time. The first column contains the retention time points in seconds, the second column the corresponding pressures in pascal." [PSI:QC]
-is_a: MS:4000006 ! table
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1003019 ! pressure chromatogram
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_column: MS:4000108 ! Retention time
-relationship: has_column: MS:4000261 ! Pressure
-
-[Term]
-id: MS:4000080
-name: Peptide elution order trailing
-def: "N(a, b) are the peptides common in the run and a reference run. N(a,b)_i to N(a,b)_j are the first to last eluting common peptides in the run ordered by retention time. This metric is the maximum of ('elution rank' of peptide N(a,b)_t in run) - ('elution_rank' of peptide N(a,b)_t in reference) for the first tenth of common peptides ordered by retention time. The metric is finally normalised with dividing by the number of (identified) peptides in the run." [PSI:QC]
-comment: The elution rank difference gives you a measure of how many peptides are eluting early.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:4000014 ! multiple runs based
-
-[Term]
-id: MS:4000081
-name: Peptide elution order preceding
-def: "N(a, b) are the peptides common in the run and a reference run. N(a,b)_i to N(a,b)_j are the first to last eluting common peptides in the run ordered by retention time. This metric is the maximum of ('elution rank' of peptide N(a,b)_t in run) - ('elution_rank' of peptide N(a,b)_t in reference) for the last tenth of common peptides ordered by retention time. The metric is finally normalised with dividing by the number of (identified) peptides in the run." [PSI:QC]
-comment: The elution rank difference gives you a measure of how many peptides are eluting late.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:4000014 ! multiple runs based
-
-[Term]
-id: MS:4000082
-name: isolation window target m/z
-def: "The primary or reference m/z about which the isolation window is defined." [PSI:QC]
-comment: The isolation window target m/z is read straight from the mzML file and reported for every unique isolation window. This serves mainly as information to orientate the user.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:1000827 ! isolation window target m/z
-
-[Term]
-id: MS:4000083
-name: scans per isolation window
-def: "The number of scans collected during the run reported for all unique isolation windows." [PSI:QC]
-comment: This is mainly informative and serves as a nice confirmation that mzML contains all the necessary information.
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000084
-name: average m/z range of isolation window
-def: "The average range (isolation window upper limit - isolation window lower limit) in m/z for each unique isolation window." [PSI:QC]
-comment: This is the range set by the user in the isolation scheme. The purpose is to provide context for other metrics.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000085
-name: proportion of total TIC per isolation window
-def: "The TIC for all occurrences of the relevant isolation window in the run is summed and divided by the total TIC for all MS2 scans in the run." [PSI:QC]
-comment: A larger value indicates that isolation windows with that particular target m/z contributed more to the total TIC.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000070 ! MS2 Total ion current chromatogram
-relationship: has_relation MS:4000082 ! isolation window target m/z
-
-[Term]
-id: MS:4000086
-name: average isolation window density
-def: "For each unique isolation window this value reports the number of ions detected on average throughout the run." [PSI:QC]
-comment: A higher value indicates that a higher number of ions was detected for this specific isolation window on average.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000082 ! isolation window target m/z
-
-[Term]
-id: MS:4000087
-name: isolation window density IQR
-def: "The interquartile range (IQR) of the number of ions detected throughout the run for each unique isolation window." [PSI:QC]
-comment: A higher value indicates greater variability in the number of ions detected for that particular isolation window.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000082 ! isolation window target m/z
-relationship: has_relation MS:4000086 ! average isolation window density
-
-[Term]
-id: MS:4000088
-name: MS2 peak widths per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. This metric returns the average FWHM for base peaks in each segment." [PSI:QC]
-comment: Sharper peak widths (i.e. smaller values) indicate better chromatographic resolution.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:1000086 ! full width at half-maximum
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000089
-name: peak tailing factor per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. This metric measures peak tailing, which can be defined as the peak width divided by twice the distance from the start of the peak to the apex, all measured at 5% height. A larger value indicates the tail of the peak is longer in comparison to the front of the peak." [PSI:QC]
-comment: The larger the value, the longer the peak tail and therefore the less symmetric the peak.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000090
-name: MS2 peak capacity per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. For this metric, the size of each segment (Identical across segments) is divided by the number of peaks in this segment. Peak capacity describes the maximum theoretical number of components that can be successfully separated with a given column." [PSI:QC]
-comment: This metric is related to peak widths. A larger peak width will result in less distinguishable peaks for the segment in question.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000022 ! chromatogram metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000088 ! MS2 peak widths
-
-[Term]
-id: MS:4000091
-name: MS2 peak precision per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. For each base peak, both the m/z and intensity of every instance in which an ion (not necessarily a base peak) within the m/z tolerance of the base peak is picked up is added to an array for m/z and an array for intensity and the mean of those arrays are determined. The mean m/z is divided by the m/z at which the base peak was reported as a base peak. This value is squared and multiplied by the intensity mean. The intensity of the base peak when it was reported as a base peak is then divided by this result." [PSI:QC]
-comment: The larger the value, the less precise the m/z value of the peak. The value is weighted so as to not penalize low intensity peaks.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000092
-name: MS1 peak precision per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. For each base peak, both the m/z and intensity of every instance in which an ion (not necessarily a base peak) within the m/z tolerance of the base peak is picked up is added to an array for m/z and an array for intensity and the mean of those arrays are determined. The mean m/z is divided by the m/z at which the base peak was reported as a base peak. This value is squared and multiplied by the intensity mean. The intensity of the base peak when it was reported as a base peak is then divided by this result." [PSI:QC]
-comment: The larger the value, the less precise the m/z value of the peak. The value is weighted so as to penalize high intensity peaks that have drifted.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000093
-name: average change in TIC per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. The TIC of a scan is subtracted from the TIC of the previous scan and the absolute value is then added to an array for all scans in the segment, of which the average is reported here. This value is reported as the average for all fragmentswindows present in that segment of the RT." [PSI:QC]
-comment: A larger value could indicate irregularities in the ionization process, such as sputter.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000067 ! Total ion current chromatogram
-
-[Term]
-id: MS:4000094
-name: IQR of change in TIC per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. The TIC of a scan is subtracted from the TIC of the previous scan and the absolute value is then added to an array for all scans in the segment, of which the interquantile range (IQR) is reported here." [PSI:QC]
-comment: A larger value indicates greater variability in the change in TIC and therefore that a greater portion of the scans might have a value that is further away from the mean.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000093 ! average change in TIC
-
-[Term]
-id: MS:4000095
-name: average cycle time per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. This metric reports the average time in seconds taken to complete a cycle in each segment." [PSI:QC]
-comment: A larger value could indicate a longer scan time which could be due to a larger amount of ions in this quantile or other factors.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000082 ! isolation window target m/z
-
-[Term]
-id: MS:4000096
-name: average number of MS1 ions detected per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. This metric reports the average number of ions reported per MS1 scan in each segment." [PSI:QC]
-comment: A larger value indicates a larger number of ions detected in this section of the RT on average.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000097
-name: average number of MS2 ions detected per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. This metric reports the average number of ions reported per MS2 scan in each segment." [PSI:QC]
-comment: A larger value indicates a larger number of ions detected in this section of the RT on average.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000098
-name: MS1 TIC per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. This metric reports the total MS1 TIC for each segment." [PSI:QC]
-comment: A larger value indicates a higher TIC.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000069 ! MS1 Total ion current chromatogram
-
-[Term]
-id: MS:4000099
-name: MS2 TIC per RT segment
-def: "For this metric the user has selected the number of segments the RT is divided into and for each segment a value is returned. The number of segments N is therefore stipulated by the user. This metric reports the total MS2 TIC for each segment." [PSI:QC]
-comment: A larger value indicates a higher TIC.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000070 ! MS2 Total ion current chromatogram
-
-[Term]
-id: MS:4000100
-name: number of missing scans
-def: "This metric is reported per run. Sometimes scans are performed, but zero ions are detected. This metric reports the number of such scans in the run." [PSI:QC]
-comment: A larger value indicates a larger number of scans within the run that did not contain a single ion.
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000101
-name: isolation windows size difference
-def: "This metric is the difference in m/z between the largest and the smallest isolation window in the run." [PSI:QC]
-comment: In SWATH/DIA this is merely for informative purposes so a user can check that there was not an error in the isolation scheme they had set up.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:1000827 ! isolation window target m/z
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000102
-name: average isolation windows per cycle
-def: "The average number of unique isolation windows per cycle for the whole run." [PSI:QC]
-comment: In SWATH/DIA this is merely informative for the user to double check that the correct isolation settings were carried out.
-xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-
-[Term]
-id: MS:4000103
-name: Total MS1 density
-def: "The sum of all abundances in all MS1 events in the run." [PSI:QC]
-comment: A higher value indicates more ions detected. When comparing runs, this value could be compared to the MS1 density average as this would give an indication whether a few scans are responsible for the bulk of the number of ions, or the load is spread evenly throughout.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000069 ! MS1 Total ion current chromatogram
-
-[Term]
-id: MS:4000104
-name: Total MS2 density
-def: "The sum of all abundances in all MS2 events in the run." [PSI:QC]
-comment: A higher value indicates more ions detected. When comparing runs, this value could be compared to the MS2 density average as this would give an indication whether a few scans are responsible for the bulk of the number of ions, or the load is spread evenly throughout.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000070 ! MS2 Total ion current chromatogram
-
-[Term]
-id: MS:4000105
-name: MS2 density average
-def: "The number of ions in each MS2 scan is averaged for all MS2 scans in the run." [PSI:QC]
-comment: A higher value indicates more ions detected. When comparing runs, this value could be compared to the MS2 density average as this would give an indication whether a few scans are responsible for the bulk of the number of ions, or the load is spread evenly throughout.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000106 ! MS2 density IQR
-
-[Term]
-id: MS:4000106
-name: MS2 density IQR
-def: "The IQR for the number of ions detected in all MS2 scans in the run." [PSI:QC]
-comment: A higher value indicates greater variability in the number of ions detected in MS2 scans.
-xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:4000013 ! QC metric relation: one run
-relationship: has_relation MS:4000105 ! MS2 density average
-
-[Term]
-id: MS:4000107
-name: Table column type
-def: "The parent to the group of column definitions for name, content, and units for table type." [PSI:QC]
-relationship: has_relation MS:4000006 ! table
-
-[Term]
-id: MS:4000108
-name: Retention time column
-def: "The column contains retention time points in seconds." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units UO:0000010 ! second
-
-[Term]
-id: MS:4000109
-name: Relative intensity column
-def: "The column contains relative intensity values of one type." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units MS:1000043 ! intensity unit
-
-[Term]
-id: MS:4000110
-name: Sequence coverage column
-def: "The column contains sequence coverage values in percent, e.g. from proteins." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units UO:0000187 ! percent
-relationship: has_type NCIT:C68811 ! Cover
-
-[Term]
-id: MS:4000111
-name: Protein accession column
-def: "The column contains protein accessions." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type MS:1000885 ! protein accession
-
-[Term]
-id: MS:4000112
-name: Sequence length column
-def: "The column contains length values of sequences, i.e. the count of items within the sequences, e.g. total length of proteins." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000113
-name: Target or decoy designation column
-def: "The column contains designations of the type 'target', 'decoy', or 'target+decoy'." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type NCIT:C45253 ! String
-
-[Term]
-id: MS:4000114
-name: Sample rate column
-def: "The column contains sample rate values as number of occurrences." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units PATO:0000161 ! rate
-
-[Term]
-id: MS:4000115
-name: Count column
-def: "The column contains counts of occurrences of a common type." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000116
-name: Peptide sequence column
-def: "The column contains peptide sequences; multiple peptides are separated by space; sequences in ProForma encoding." [PSI:QC]
-comment: ProForma v2 - https://github.com/HUPO-PSI/ProForma/
-is_a: MS:4000107 ! Table column type
-relationship: has_type NCIT:C45253 ! String
-
-[Term]
-id: MS:4000117
-name: Outliers below column
-def: "The outlier values below 1.5 * IQR." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type NCIT:C79083 ! Outlier
-
-[Term]
-id: MS:4000118
-name: Outliers above column
-def: "The outlier values above 1.5 * IQR." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type NCIT:C79083 ! Outlier
-
-[Term]
-id: MS:4000119
-name: Protein coverage
-def: "The coverage of protein sequences from the peptide sequences identified. The table records the coverage itself (in percent), the protein accession (SHOULD correspond to the accession used in fasta document used for Sequence DB based identification), Length of the protein(, and optionally if it is 'target' or 'decoy' entry.)" [PSI:QC]
-comment: The protein coverage can provide insight into the sensitivity of the instrument/identification/protocols used.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000006 ! table
-relationship: has_column MS:4000110 ! Sequence coverage column
-relationship: has_column MS:4000111 ! Protein accession column
-relationship: has_column MS:4000112 ! Sequence length column
-relationship: has_optional_column MS:4000113 ! Target or decoy designation column
-
-[Term]
-id: MS:4000120
-name: Sampling rates
-def: "The sampling rates of identified peptides and their respective frequency (accumulated by the sampling rate, i.e. how often peptides were sampled n times and how many peptides were resampled at that rate. Optionally, which peptides were sampled at that rate, space separated)" [PSI:QC]
-comment: The sampling rate may give insights to peptide separation, dynamic exclusion settings and gradient efficiency.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000006 ! table
-relationship: has_column MS:4000114 ! Sample rate column
-relationship: has_column MS:4000115 ! Count column
-relationship: has_optional_column MS:4000116 ! Peptide sequence column
-
-[Term]
-id: MS:4000121
-name: Explained precursor intensity first quarter
-def: "Fraction of identified MS2 in the first quarter of MS2 sorted by precursor intensity." [PSI:QC]
-comment: Higher fractions of identified MS2 spectra indicate the efficiency of detection and sampling
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "MS2-4A" NARROW []
-
-[Term]
-id: MS:4000122
-name: Explained precursor intensity second quarter
-def: "Fraction of identified MS2 in the second quarter of MS2 sorted by precursor intensity." [PSI:QC]
-comment: Higher fractions of identified MS2 spectra indicate the efficiency of detection and sampling
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "MS2-4B" NARROW []
-
-[Term]
-id: MS:4000123
-name: Explained precursor intensity third quarter
-def: "Fraction of identified MS2 in the third quarter of MS2 sorted by precursor intensity." [PSI:QC]
-comment: Higher fractions of identified MS2 spectra indicate the efficiency of detection and sampling
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "MS2-4C" NARROW []
-
-[Term]
-id: MS:4000124
-name: Explained precursor intensity fourth quarter
-def: "Fraction of identified MS2 in the fourth quarter of MS2 sorted by precursor intensity." [PSI:QC]
-comment: Higher fractions of identified MS2 spectra indicate the efficiency of detection and sampling
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "MS2-4D" NARROW []
-
-[Term]
-id: MS:4000125
-name: Extent of identified precursor intensity
-def: "Ratio of 95th over 5th percentile of precursor intensity for identified peptides" [PSI:QC]
-comment: Can be used to approximate the dynamic range of signal
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000300 ! dimensionless ratio
-synonym: "MS1-3A" NARROW []
-
-[Term]
-id: MS:4000126
-name: Precursor intensity range of identified MS2
-def: "Minimum and maximum precursor intensity recorded and identified." [PSI:QC]
-comment: The intensity range of the identified precursors informs about the dynamic range of the acquisition.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units MS:1003085 ! previous MSn-1 scan precursor intensity
-
-[Term]
-id: MS:4000127
-name: Precursor intensity of identified MS2 Q1, Q2, Q3
-def: "From the distribution of precursor intensity of identified MS2, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: The (un)identified precursor intensity distribution can aid the interpretation of overall identification success.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000128
-name: Precursor intensity of unidentified MS2 Q1, Q2, Q3
-def: "From the distribution of precursor intensity of unidentified MS2, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: The (un)identified precursor intensity distribution can aid the interpretation of overall identification success.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000129
-name: Median S/N for MS1 spectra in RT range in which half of the identified spectra are identified
-def: "Median S/N for MS1 spectra whose RT is between Q1-Q3 of identified MS2 spectra. This will be half of the identified MS2 spectra." [PSI:QC]
-comment: Higher MS1 S/N may correlate with higher signal discrimination
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000300 ! dimensionless ratio
-synonym: "MS1-2A" NARROW []
-
-[Term]
-id: MS:4000130
-name: Median of TIC values in the RT range in which the middle half of peptides are identified
-def: "Median of TIC values in the RT range in which half of peptides are identified (RT values of Q1 to Q3 of identifications)"  [PSI:QC]
-comment: Estimates the total absolute signal for peptides (may vary significantly between instruments)
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "MS1-2B" NARROW []
-
-[Term]
-id: MS:4000131
-name: Median S/N for MS1 spectra in the shortest RT range in which half of the peptides are identified
-def: "Median S/N for MS1 spectra in the shortest RT range in which half of the peptides are identified" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-
-[Term]
-id: MS:4000132
-name: Median of TIC values in the shortest RT range in which half of the peptides are identified
-def: "Median of TIC values in the shortest RT range in which half of the peptides are identified"  [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-
-[Term]
-id: MS:4000133
-name: Explained base peak intensity median
-def: "Median of the ratio of 'max survey scan intensity' over 'sampled precursor intensity' for all peptides identified"  [PSI:QC]
-comment: Gives insight into the amount of overall explained signal and whether the amount of signal could be increased by a better sampling strategy.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000574 ! center value
-
-[Term]
-id: MS:4000134
-name: Explained base peak intensity median from least intense 50% base peaks
-def: "Ratios of 'max survey scan intensity' over sampled precursor intensity for the bottom half (by MS1 max) of MS2" [PSI:QC]
-comment: Gives insight into the amount of explained signal and whether the sampling strategy is interfering with the sampling of low abundant peaks.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-
-[Term]
-id: MS:4000135
-name: Number of chromatograms
-def: "Number of chromatograms" [PSI:QC]
-comment: A lower number of chromatograms acquired during one sample run compared to similar runs can indicate mismatched instrument settings or issues with the instrumentation.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000138
-name: MZ acquisition range
-def: "Upper and lower limit of m/z values at which spectra are recorded." [PSI:QC]
-comment: Acquisition levels can be used as a criterion to assess the comparability of instrument settings between runs.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units MS:1000040 ! m/z
-
-[Term]
-id: MS:4000139
-name: RT acquisition range
-def: "Upper and lower limit of time at which spectra are recorded." [PSI:QC]
-comment: Acquisition levels can be used as a criterion to assess the comparability of instrument settings between runs.
-is_a: MS:4000004 ! n-tuple
-relationship: has_units UO:0000010 ! second
 
 [Term]
 id: MS:4000140
 name: Fastest frequency for MS level 1 collection
 def: "Fastest frequency for MS level 1 collection" [PSI:QC]
 comment: Spectrum acquisition frequency can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:1000029 ! sampling frequency
-relationship: has_relation MS:1000580 ! MSn spectrum
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_units UO:0000106 ! hertz
 synonym: "MS1-Freq-Max" EXACT []
+is_a: MS:4000003 ! single value
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000023 ! MS1 metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
+relationship: has_units UO:0000106 ! hertz
 
 [Term]
 id: MS:4000141
 name: Fastest frequency for MS level 2 collection
 def: "Fastest frequency for MS level 2 collection" [PSI:QC]
 comment: Spectrum acquisition frequency can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000024 ! MS2 metric
-relationship: has_relation MS:1000029 ! sampling frequency
-relationship: has_relation MS:1000580 ! MSn spectrum
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_units UO:0000106 ! hertz
-relationship: has_units UO:0000106 ! hertz
 synonym: "MS2-Freq-Max" EXACT []
-
-[Term]
-id: MS:4000142
-name: Slowest frequency for MS level 1 collection
-def: "Slowest frequency for MS level 1 collection" [PSI:QC]
-comment: Spectrum acquisition frequency can be used to gauge the suitability of used instrument settings for the sample content used.
 is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000024 ! MS2 metric
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term
 relationship: has_units UO:0000106 ! hertz
 
 [Term]
-id: MS:4000143
-name: Slowest frequency for MS level 2 collection
-def: "Slowest frequency for MS level 2 collection" [PSI:QC]
-comment: Spectrum acquisition frequency can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units UO:0000106 ! hertz
-
-[Term]
-id: MS:4000144
-name: Precursor intensity range
-def: "Minimum and maximum precursor intensity recorded." [PSI:QC]
-comment: The intensity range of the precursors informs about the dynamic range of the acquisition.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
+id: MS:4000259
+name: MS1 density per quantile
+def: "The first to n-th quantile of MS1 scan peak counts." [PSI:QC]
+synonym: "MS1-Density-Q1" RELATED []
+synonym: "MS1-Density-Q2" RELATED []
+synonym: "MS1-Density-Q3" RELATED []
 is_a: MS:4000004 ! n-tuple
-relationship: has_units MS:1003085 ! previous MSn-1 scan precursor intensity
-
-[Term]
-id: MS:4000145
-name: MS1 frequency in RT quarters
-def: "MS1 frequency in RT 1st quarter, 2nd quarter, 3rd quarter, 4th quarter" [PSI:QC]
-comment: Spectrum acquisition frequency can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units UO:0000106 ! hertz
-
-[Term]
-id: MS:4000146
-name: MS2 frequency in RT quarters
-def: "MS2 frequency in RT 1st quarter, 2nd quarter, 3rd quarter, 4th quarter" [PSI:QC]
-comment: Spectrum acquisition frequency can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units UO:0000106 ! hertz
-
-[Term]
-id: MS:4000147
-name: MS1 ion collection time Q1, Q2, Q3
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000148
-name: MS1 ion collection time mean
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the mean" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000149
-name: MS1 ion collection time sigma
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the sigma value" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000150
-name: MS1 ion collection time low outliers (<Q1-1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers below Q1-1.5*IQR" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000151
-name: MS1 ion collection time high outliers (>Q3+1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS1, the list of outliers above Q3+1.5*IQR" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000152
-name: MS2 ion collection time Q1, Q2, Q3
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000153
-name: MS2 ion collection time mean
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the mean" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000154
-name: MS2 ion collection time sigma
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the sigma value" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000155
-name: MS2 ion collection time low outliers (<Q1-1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers below Q1-1.5*IQR" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000156
-name: MS2 ion collection time high outliers (>Q3+1.5*IQR)
-def: "From the distribution of ion injection times (MS:1000927) for MS2, the list of outliers above Q3+1.5*IQR" [PSI:QC]
-comment: Injection time distribution can be used to gauge the suitability of used instrument settings for the sample content used.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000157
-name: Peak density distribution MS1 Q1, Q2, Q3
-def: "From the distribution of peak densities in MS1, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000158
-name: Peak density distribution MS1 mean
-def: "From the distribution of peak densities in MS1, the mean" [PSI:QC]
-comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000159
-name: Peak density distribution MS1 sigma
-def: "From the distribution of peak densities in MS1, the sigma value" [PSI:QC]
-comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000160
-name: Peak density distribution MS1 low outliers (<Q1-1.5*IQR)
-def: "From the distribution of peak densities in MS1, the list of outliers below Q1-1.5*IQR" [PSI:QC]
-comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000161
-name: Peak density distribution MS1 high outliers (>Q3+1.5*IQR)
-def: "From the distribution of peak densities in MS1, the list of outliers above Q3+1.5*IQR" [PSI:QC]
-comment: The distribution of peak densities in MS1 can provide insight into the presence of nuisance factors.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000162
-name: Peak density distribution MS2 Q1, Q2, Q3
-def: "From the distribution of peak densities in MS2, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_type STATO:0000167 ! first quartile
-relationship: has_type STATO:0000574 ! center value
-relationship: has_type STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000163
-name: Peak density distribution MS2 mean
-def: "From the distribution of peak densities in MS2, the mean" [PSI:QC]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000164
-name: Peak density distribution MS2 sigma
-def: "From the distribution of peak densities in MS2, the sigma value" [PSI:QC]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000165
-name: Peak density distribution MS2 low outliers (<Q1-1.5*IQR)
-def: "From the distribution of peak densities in MS2, the list of outliers below Q1-1.5*IQR" [PSI:QC]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000166
-name: Peak density distribution MS2 high outliers (>Q3+1.5*IQR)
-def: "From the distribution of peak densities in MS2, the list of outliers above Q3+1.5*IQR" [PSI:QC]
-comment: The distribution of peak densities in MS2 can provide insight into the instruments ion selction settings.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000167
-name: Precursor intensity distribution Q1, Q2, Q3
-def: "From the distribution of precursor intensities, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000168
-name: Precursor intensity distribution mean
-def: "From the distribution of precursor intensities, the mean" [PSI:QC]
-comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000169
-name: Precursor intensity distribution sigma
-def: "From the distribution of precursor intensities, the sigma value" [PSI:QC]
-comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000170
-name: Precursor intensity distribution low outliers (<Q1-1.5*IQR)
-def: "From the distribution of precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:QC]
-comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000171
-name: Precursor intensity distribution high outliers (>Q3+1.5*IQR)
-def: "From the distribution of precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:QC]
-comment: The intensity distribution of the precursors informs about the dynamic range of the acquisition.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000172
-name: MS1 signal jump (10x) count
-def: "The count of MS1 signal jump (spectra sum) by a factor of ten or more (10x) between two subsequent scans" [PSI:QC]
-comment: An unusual high count of signal jumps or falls can indicate ESI stability issues.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-synonym: "IS-1A"  RELATED []
-
-[Term]
-id: MS:4000173
-name: MS1 signal fall (10x) count
-def: "The count of MS1 signal decline (spectra sum) by a factor of ten or more (10x) between two subsequent scans" [PSI:QC]
-comment: An unusual high count of signal jumps or falls can indicate ESI stability issues.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-synonym: "IS-1B"  RELATED []
-
-[Term]
-id: MS:4000174
-name: Charged peptides ratio 1+ over 2+
-def: "Ratio of 1+ peptide count  over 2+ peptide count  in identified spectra" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "IS-3A" NARROW []
-
-[Term]
-id: MS:4000175
-name: Charged peptides ratio 3+ over 2+
-def: "Ratio of 3+ peptide count over 2+ peptide count in identified spectra" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "IS-3B" NARROW []
-
-[Term]
-id: MS:4000176
-name: Charged peptides ratio 4+ over 2+
-def: "Ratio of 4+ peptide count over 2+ peptide count in identified spectra" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-synonym: "IS-3C" NARROW []
-
-[Term]
-id: MS:4000177
-name: Mean charge in identified spectra
-def: "Mean charge in identified spectra" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-
-[Term]
-id: MS:4000178
-name: Median charge in identified spectra
-def: "Median charge in identified spectra" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-
-[Term]
-id: MS:4000179
-name: Charged spectra ratio +1 over +2
-def: "Ratio of 1+ spectra count over 2+ spectra count in all MS2" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-synonym: "IS-3A"  RELATED []
-
-[Term]
-id: MS:4000180
-name: Charged spectra ratio +3 over +2
-def: "Ratio of 3+ peptide count over 2+ peptide count in all MS2" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-synonym: "IS-3B"  RELATED []
-
-[Term]
-id: MS:4000181
-name: Charged spectra ratio +4 over +2
-def: "Ratio of 4+ peptide count over 2+ peptide count in all MS2" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-synonym: "IS-3C"  RELATED []
-
-[Term]
-id: MS:4000182
-name: Mean precursor charge in all MS2
-def: "Mean precursor charge in all MS2" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-
-[Term]
-id: MS:4000183
-name: Median precursor charge in all MS2
-def: "Median precursor charge in all MS2" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-
-[Term]
-id: MS:4000184
-name: Number of different distinct proteins from all PSM
-def: "Number of different distinct protein from all PSM after FDR filtering. (No undistinguishability groups.)" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
+relationship: has_metric_category MS:4000013 ! single run based
+relationship: has_metric_category MS:4000010 ! ID free
+relationship: has_metric_category MS:4000023 ! MS1 metric
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000185
-name: Number of identified proteins
-def: "Number of identified proteins at given FDR threshold, first number is the number of proteins (considering sequence only), second number is the FDR threshold applied (negative if no threshold applied)" [PSI:QC]
-comment: The number of identifications are likely to only make local sense within a confined set of identification parameters (identification algorithm, searchspace, FDR method).
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000186
-name: Total number of PSM
-def: "Total number of PSM before FDR filtering." [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000187
-name: Number of identified peptides
-def: "Number of identified peptides at given FDR threshold, first number is the number of peptides (considering sequence only), second number is the FDR threshold applied (negative if no threshold applied)" [PSI:QC]
-comment: The number of identifications are likely to only make local sense within a confined set of identification parameters (identification algorithm, searchspace, FDR method).
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000188
-name: Number of identified spectra
-def: "Number of identified spectra at given FDR threshold, first number is the number of spectra, second number is the FDR threshold applied (negative if no threshold applied)" [PSI:QC]
-comment: The number of identifications are likely to only make local sense within a confined set of identification parameters (identification algorithm, searchspace, FDR method).
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000189
-name: ID ratio
-def: "The ratio of identified and recorded MS2 spectra after FDR filtering." [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000300 ! dimensionless ratio
-
-[Term]
-id: MS:4000190
-name: Precursor errors (Da) Q1, Q2, Q3
-def: "From the distribution of Precursor errors (mass deviation of precursor to identified peptide in Da), the quartiles Q1, Q2, Q3 value" [PSI:QC]
-comment: The absolute precursor error distribution can aid the interpretation of overall identification success.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000191
-name: Precursor errors (Da) mean
-comment: The absolute precursor error distribution can aid the interpretation of overall identification success.
-def: "From the distribution of Precursor errors (mass deviation of precursor to identified peptide in Da), the mean" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-synonym: "MS1-5B" NARROW []
-
-[Term]
-id: MS:4000192
-name: Precursor errors (Da) sigma
-def: "From the distribution of Precursor errors (mass deviation of precursor to identified peptide in Da), the sigma value" [PSI:QC]
-comment: The absolute precursor error distribution can aid the interpretation of overall identification success.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000193
-name: Precursor errors (Da) outliers (<Q1-1.5*IQR)
-def: "From the distribution of Precursor errors (mass deviation of precursor to identified peptide in Da), the list of outliers below Q1-1.5IQR" [PSI:QC]
-comment: The absolute precursor error distribution can aid the interpretation of overall identification success.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000006 ! table
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000194
-name: Precursor errors (Da) outliers (>Q3+1.5*IQR)
-def: "From the distribution of Precursor errors (mass deviation of precursor to identified peptide in Da), the list of outliers above Q3+1.5IQR" [PSI:QC]
-comment: The absolute precursor error distribution can aid the interpretation of overall identification success.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000006 ! table
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000195
-name: Precursor errors (ppm) Q1, Q2, Q3
-comment: The precursor error in ppm distribution can aid the interpretation of overall identification success.
-def: "From the distribution of Precursor errors (ppm), the quartiles Q1, Q2, Q3 value" [PSI:QC]
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000196
-name: Precursor errors (ppm) mean
-def: "From the distribution of Precursor errors (ppm), the mean " [PSI:QC]
-comment: The precursor error in ppm distribution can aid the interpretation of overall identification success.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000197
-name: Precursor errors (ppm) sigma
-def: "From the distribution of Precursor errors (ppm), the sigma value" [PSI:QC]
-comment: The precursor error in ppm distribution can aid the interpretation of overall identification success.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000198
-name: Precursor errors (ppm) low outliers (<Q1-1.5*IQR)
-def: "From the distribution of Precursor errors (ppm), the list of outliers above Q3+1.5IQR" [PSI:QC]
-comment: The precursor error in ppm distribution can aid the interpretation of overall identification success.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000199
-name: Precursor errors (ppm) outliers (>Q3+1.5*IQR)
-def: "From the distribution of Precursor errors (ppm), the list of outliers below Q1-1.5IQR" [PSI:QC]
-comment: The precursor error in ppm distribution can aid the interpretation of overall identification success.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000200
-name: Precursor errors (Da) median
-def: "From the distribution of Precursor errors (Da), the median" [PSI:QC]
-comment: The precursor error distribution can aid the interpretation of overall identification success.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-synonym: "MS1-5A" NARROW []
-
-[Term]
-id: MS:4000201
-name: Precursor errors (ppm) median
-def: "From the distribution of Precursor errors (ppm), the median" [PSI:QC]
-comment: The precursor error in ppm distribution can aid the interpretation of overall identification success.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-synonym: "MS1-5C" NARROW []
-
-[Term]
-id: MS:4000202
-name: Precursor errors (ppm) IQR
-def: "From the distribution of Precursor errors (ppm), the IQR" [PSI:QC]
-comment: The precursor error in ppm distribution can aid the interpretation of overall identification success.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-synonym: "MS1-5D" NARROW []
-
-[Term]
-id: MS:4000203
-name: Identification score - Q1, Q2, Q3
-def: "From the distribution of Identification score, the Q1, Q2, Q3 value" [PSI:QC]
-comment: The identification score distribution can help improve scoring function tuning, aid the interpretation of overall identification success, and integration with downstream processing such as percolator. Comparisons will likely only make local sense where the same method of identification is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000204
-name: Identification score - mean
-def: "From the distribution of Identification score, the mean value" [PSI:QC]
-comment: The identification score distribution can help improve scoring function tuning, aid the interpretation of overall identification success, and integration with downstream processing such as percolator. Comparisons will likely only make local sense where the same method of identification is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000205
-name: Identification score - sigma
-def: "From the distribution of Identification score, the sigma value" [PSI:QC]
-comment: The identification score distribution can help improve scoring function tuning, aid the interpretation of overall identification success, and integration with downstream processing such as percolator. Comparisons will likely only make local sense where the same method of identification is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000206
-name: Identification score - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of Identification score, the list of outliers below Q1-1.5IQR" [PSI:QC]
-comment: The identification score distribution can help improve scoring function tuning, aid the interpretation of overall identification success, and integration with downstream processing such as percolator. Comparisons will likely only make local sense where the same method of identification is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000207
-name: Identification score - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of Identification score, the list of outliers above Q3+1.5IQR" [PSI:QC]
-comment: The identification score distribution can help improve scoring function tuning, aid the interpretation of overall identification success, and integration with downstream processing such as percolator. Comparisons will likely only make local sense where the same method of identification is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000208
-name: Missed cleavages - Q1, Q2, Q3
-def: "From the distribution of missed cleavages in identified peptides the quartiles Q1, Q2, Q3 value" [PSI:QC]
-comment: The missed cleavage distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000209
-name: Missed cleavages - mean
-def: "From the distribution of missed cleavages in identified peptides the mean" [PSI:QC]
-comment: The missed cleavage distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000401 ! sample mean
-synonym: "MS1-5B" NARROW []
-
-[Term]
-id: MS:4000210
-name: Missed cleavages - sigma
-def: "From the distribution of missed cleavages in identified peptides the sigma value" [PSI:QC]
-comment: The missed cleavage distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000211
-name: Missed cleavages - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of missed cleavages in identified peptides, the list of outliers below Q1-1.5IQR" [PSI:QC]
-comment: The missed cleavage distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000212
-name: Missed cleavages - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of missed cleavages in identified peptides, the list of outliers above Q3+1.5IQR" [PSI:QC]
-comment: The missed cleavage distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000213
-name: Identified peptide lengths - Q1, Q2, Q3
-def: "From the distribution of identified peptide lengths the quartiles Q1, Q2, Q3 value" [PSI:QC]
-comment: The identified peptide lengths distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000214
-name: Identified peptide lengths - mean
-def: "From the distribution of identified peptide lengths the mean" [PSI:QC]
-comment: The identified peptide lengths distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000401 ! sample mean
-synonym: "MS1-5B" NARROW []
-
-[Term]
-id: MS:4000215
-name: Identified peptide lengths - sigma
-def: "From the distribution of identified peptide lengths the sigma value" [PSI:QC]
-comment: The identified peptide lengths distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000216
-name: Identified peptide lengths - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of identified peptide lengths, the list of outliers below Q1-1.5IQR" [PSI:QC]
-comment: The identified peptide lengths distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000217
-name: Identified peptide lengths - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of identified peptide lengths, the list of outliers above Q3+1.5IQR" [PSI:QC]
-comment: The identified peptide lengths distribution can aid the interpretation of digestion efficacy.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000218
-name: Signal-to-noise ratio in MS1 - Q1, Q2, Q3
-def: "From the distribution of signal-to-noise ratio in MS1, the quartiles Q1, Q2, Q3 value" [PSI:QC]
-comment: The Signal-to-noise ratio in MS1 distribution can provide insight to the presence of nuisance factors.
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000219
-name: Signal-to-noise ratio in MS1 - mean
-comment: The signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-def: "From the distribution of signal-to-noise ratio in MS1, the mean" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000220
-name: Signal-to-noise ratio in MS1 - sigma
-def: "From the distribution of signal-to-noise ratio in MS1, the sigma value" [PSI:QC]
-comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000221
-name: Signal-to-noise ratio in MS1 - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers below Q1-1.5IQR" [PSI:QC]
-comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000222
-name: Signal-to-noise ratio in MS1 - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of signal-to-noise ratio in MS1, the list of outliers above Q3+1.5IQR" [PSI:QC]
-comment: The Signal-to-noise ratio in MS1 distribution can provide insight into the presence of nuisance factors. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000223
-name: Signal-to-noise ratio in MS2 - Q1, Q2, Q3
-def: "From the distribution of signal-to-noise ratio in MS2, the quartiles Q1, Q2, Q3 value" [PSI:QC]
-comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000224
-name: Signal-to-noise ratio in MS2 - mean
-def: "From the distribution of signal-to-noise ratio in MS2, the mean" [PSI:QC]
-comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000225
-name: Signal-to-noise ratio in MS2 - sigma
-def: "From the distribution of signal-to-noise ratio in MS2, the sigma value" [PSI:QC]
-comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000226
-name: Signal-to-noise ratio in MS2 - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers below Q1-1.5IQR" [PSI:QC]
-comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000227
-name: Signal-to-noise ratio in MS2 - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of signal-to-noise ratio in MS2, the list of outliers above Q3+1.5IQR" [PSI:QC]
-comment: A high signal-to-noise ratio in MS2 distribution can explain a high rate of unidentified spectra. Comparisons will likely only make local sense where the same method of S/N calculation is applied (or overall the same software to calculate this metric, see mzQC 'analysisSoftware').
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000228
-name: Identified precursor intensity distribution Q1, Q2, Q3
-def: "From the distribution of identified precursor intensities, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: The intensity distribution of the identified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000229
-name: Identified precursor intensity distribution - mean
-def: "From the distribution of identified precursor intensities, the mean" [PSI:QC]
-comment: The intensity distribution of the identified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000230
-name: Identified precursor intensity distribution - sigma
-def: "From the distribution of identified precursor intensities, the sigma value" [PSI:QC]
-comment: The intensity distribution of the identified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000231
-name: Identified precursor intensity distribution - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of identified precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:QC]
-comment: The intensity distribution of the identified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000232
-name: Identified precursor intensity distribution - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of identified precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:QC]
-comment: The intensity distribution of the identified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
-
-[Term]
-id: MS:4000233
-name: Unidentified precursor intensity distribution - Q1, Q2, Q3
-def: "From the distribution of unidentified precursor intensities, the quartiles Q1, Q2, Q3" [PSI:QC]
-comment: The intensity distribution of the unidentified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_units STATO:0000167 ! first quartile
-relationship: has_units STATO:0000574 ! center value
-relationship: has_units STATO:0000170 ! third quartile
-
-[Term]
-id: MS:4000234
-name:  Unidentified precursor intensity distribution - mean
-def: "From the distribution of unidentified precursor intensities, the mean" [PSI:QC]
-comment: The intensity distribution of the unidentified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000003 ! single value
-relationship: has_units STATO:0000401 ! sample mean
-
-[Term]
-id: MS:4000235
-name: Unidentified precursor intensity distribution - sigma
-def: "From the distribution of unidentified precursor intensities, the sigma value" [PSI:QC]
-comment: The intensity distribution of the unidentified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000003 ! single value
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-relationship: has_units STATO:0000237 ! standard deviation
-
-[Term]
-id: MS:4000236
-name: Unidentified precursor intensity distribution - low outliers (<Q1-1.5*IQR)
-def: "From the distribution of unidentified precursor intensities, the list of outliers below Q1-1.5*IQR" [PSI:QC]
-comment: The intensity distribution of the unidentified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000117 ! Outliers below column
-
-[Term]
-id: MS:4000237
-name: Unidentified precursor intensity distribution - high outliers (>Q3+1.5*IQR)
-def: "From the distribution of unidentified precursor intensities, the list of outliers above Q3+1.5*IQR" [PSI:QC]
-comment: The intensity distribution of the unidentified precursors informs about the dynamic range of the acquisition in relation to identifiability.
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000004 ! n-tuple
-relationship: has_column MS:4000118 ! Outliers above column
 
 [Term]
 id: MS:4000238
@@ -2154,6 +449,7 @@ name: Charge state column
 def: "The column contains charge states." [PSI:QC]
 is_a: MS:4000107 ! Table column type
 relationship: has_units MS:1000041 ! charge state
+relationship: has_value_type xsd\:int ! The allowed value-type for this CV term
 
 [Term]
 id: MS:4000239
@@ -2161,236 +457,4 @@ name: Fraction column
 def: "The column contains fraction values as decimals." [PSI:QC]
 is_a: MS:4000107 ! Table column type
 relationship: has_units UO:0000191 ! fraction
-
-[Term]
-id: MS:4000240
-name: Humidity column
-def: "The column contains relative humidity values in percent." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units UO:0000187 ! percent
-
-[Term]
-id: MS:4000241
-name: Observed MS1 feature areas column
-def: "Observed MS1 feature areas." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type MS:1001844 ! MS1 feature area
-
-[Term]
-id: MS:4000242
-name: QC2 sample MS1 feature areas
-def: "Observed MS1 feature area from selected peptides of a QC2 sample measurement within 5 ppm and +/- 240 s RT tolerance. Selected peptides in the first column to be expected: 'YAEAVTR','STLTDSLVC(Carbamidomethyl)K','SLADELALVDVLEDK','NPDDITNEEYGEFYK','LAVDEEENADNNTK','FEELNMDLFR','EAALSTALSEK','DDVAQTDLLQIDPNFGSK','RFPGYDSESK','EATTEFSVDAR','EQFLDGDGWTSR','TPAQFDADELR','LGDLYEEEMR','EVSTYIK','FAFQAEVNR'" [PSI:QC]
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000006 ! table
-relationship: has_column: MS:4000116 ! Peptide sequence
-relationship: has_column: MS:4000241 ! Observed MS1 feature areas
-
-[Term]
-id: MS:4000243
-name: Observed mass accuracies column
-def: "Observed mass accuracy calculated by 1E6 x (observed mz - theoretical mz)/theoretical mz of selected peptides." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type MS:1000014 ! accuracy
-
-[Term]
-id: MS:4000244
-name: QC2 sample mass accuracies
-def: "Observed mass accuracy from selected peptides of a QC2 sample measurement. Selected peptides in the first column to be expected: 'YAEAVTR','STLTDSLVC(Carbamidomethyl)K','SLADELALVDVLEDK','NPDDITNEEYGEFYK','LAVDEEENADNNTK','FEELNMDLFR','EAALSTALSEK','DDVAQTDLLQIDPNFGSK','RFPGYDSESK','EATTEFSVDAR','EQFLDGDGWTSR','TPAQFDADELR','LGDLYEEEMR','EVSTYIK','FAFQAEVNR'" [PSI:QC]
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000009 ! ID based
-is_a: MS:4000006 ! table
-relationship: has_column: MS:4000116 ! Peptide sequence
-relationship: has_column: MS:4000243 ! Observed mass accuracies
-
-[Term]
-id: MS:4000245
-name: Number of different undistinguishable proteins groups from all PSM
-def: "Number of different undistinguishable proteins groups from all PSM after FDR filtering. (Only undistinguishability groups.)" [PSI:QC]
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-is_a: MS:4000001 ! QC metric
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000246
-name: Run name column
-def: "The column contains run names as defined by runQuality inputFile name." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-
-[Term]
-id: MS:4000247
-name: PCA Dimension 1 column
-def: "The column contains Principal Component Analysis scores from the first eigenvalue dimension." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type STATO:0000587 ! percentage of variance
-
-[Term]
-id: MS:4000248
-name: PCA Dimension 2 column
-def: "The column contains Principal Component Analysis scores from the second eigenvalue dimension." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type STATO:0000587 ! percentage of variance
-
-[Term]
-id: MS:4000249
-name: PCA Dimension 3 column
-def: "The column contains Principal Component Analysis scores from the third eigenvalue dimension." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type STATO:0000587 ! percentage of variance
-
-[Term]
-id: MS:4000250
-name: PCA Dimension 4 column
-def: "The column contains Principal Component Analysis scores from the fourth eigenvalue dimension." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type STATO:0000587 ! percentage of variance
-
-[Term]
-id: MS:4000251
-name: PCA Dimension 5 column
-def: "The column contains Principal Component Analysis scores from the fifth eigenvalue dimension." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_type STATO:0000587 ! percentage of variance
-
-[Term]
-id: MS:4000252
-name: Batch label column
-def: "The column contains batch label names" [PSI:QC]
-is_a: MS:4000107 ! Table column type
-
-[Term]
-id: MS:4000253
-name: Injection sequence number column
-def: "The column contains the order in which the runs were acquired. Numbers may be missing due to unrelated samples being run." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-
-[Term]
-id: MS:4000254
-name: Peak area feature PCA result
-def: "PCA score result from multiple runs with (log transformed) peak area input features before batch correction." [PSI:QC]
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000006 ! table
-relationship: has_column: MS:4000246 ! Run name
-relationship: has_column: MS:4000247 ! PCA Dimension 1
-relationship: has_column: MS:4000248 ! PCA Dimension 2
-relationship: has_optional_column: MS:4000249 ! PCA Dimension 3
-relationship: has_optional_column: MS:4000250 ! PCA Dimension 4
-relationship: has_optional_column: MS:4000251 ! PCA Dimension 5
-relationship: has_optional_column: MS:4000252 ! Batch label
-relationship: has_optional_column: MS:4000253 ! Injection sequence number
-
-[Term]
-id: MS:4000255
-name: Batch corrected peak area feature PCA result
-def: "PCA score result from multiple runs with (log transformed) peak area input features after batch correction." [PSI:QC]
-is_a: MS:4000001 ! QC metric
-is_a: MS:4000010 ! ID free
-is_a: MS:4000006 ! table
-relationship: has_column: MS:4000246 ! Run name
-relationship: has_column: MS:4000247 ! PCA Dimension 1
-relationship: has_column: MS:4000248 ! PCA Dimension 2
-relationship: has_optional_column: MS:4000249 ! PCA Dimension 3
-relationship: has_optional_column: MS:4000250 ! PCA Dimension 4
-relationship: has_optional_column: MS:4000251 ! PCA Dimension 5
-relationship: has_optional_column: MS:4000252 ! Batch label
-relationship: has_optional_column: MS:4000253 ! Injection sequence number
-
-[Term]
-id: MS:4000256
-name: Metabolomics metric
-def: "Metrics for metabolomics experiments." [PSI:QC]
-is_a: MS:4000008 ! QC metric category
-
-[Term]
-id: MS:4000257
-name: "Detected Compounds"
-def: "Number of detected compounds from a given library of target compounds in a specific run." [PSI:QC]
-is_a: MS:4000256 ! Metabolomics metric
-is_a: MS:4000003 ! single value
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_units UO:0000189 ! count unit
-
-[Term]
-id: MS:4000259
-name: MS1 density per quantile
-def: "The first to n-th quantile of MS1 scan peak counts." [PSI:QC]
-is_a: MS:4000004 ! n-tuple
-is_a: MS:4000010 ! ID free
-is_a: MS:4000023 ! MS1 metric
-relationship: has_relation MS:1000035 ! peak picking
-relationship: has_relation MS:4000013 ! single run based
-synonym: "MS1-Density-Q1" RELATED []
-synonym: "MS1-Density-Q2" RELATED []
-synonym: "MS1-Density-Q3" RELATED []
-
-[Term]
-id: MS:4000260
-name: Percentage column
-def: "The column contains percentages of one type." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units UO:0000187 ! percent
-
-[Term]
-id: MS:4000261
-name: Pressure column
-def: "The column contains measurements of pressure in pascal." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-relationship: has_units UO:0000110 ! pascal
-
-[Term]
-id: MS:4000262
-name: Retention time mean shift
-def: "Based on reference retention times of detected features the mean shift of all features is calculated in seconds." [PSI:QC]
-comment: Low deviation in retention time indicates consistency and reproducibility in chromatographic separation.
-is_a: MS:4000003 ! single value
-is_a: MS:4000009 ! ID based
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_units UO:0000010 ! second
-
-[Term]
-id: MS:4000263
-name: Pump pressure mean
-def: "The mean pump pressure in bar for the whole run." [PSI:QC]
-comment: Detecting inconsistencies in pump pressure between runs early helps troubleshooting and prevents instrument damage.
-is_a: MS:4000003 ! single value
-is_a: MS:4000010 ! ID free
-relationship: has_relation MS:4000013 ! single run based
-relationship: has_relation MS:1003019 ! pressure chromatogram
-relationship: has_relation MS:4000079 ! Pump pressure chromatogram
-
-[Term]
-id: MS:4000264
-name: group of runs
-def: "A table with two columns 'inputfile-name' and 'group-label' which maps input files to group names. Inputfile names must occur only once and correspond to the 'metadata:inputfiles[x]:name' attribute in the mzQC JSON schema." [PSI:QC]
-is_a: MS:4000006 ! table
-is_a: MS:4000009 ! ID based
-relationship: has_column: MS:4000265 ! inputfile-name
-relationship: has_column: MS:4000266 ! group-label
-
-[Term]
-id: MS:4000265
-name: InputFile-name column
-def: "The column contains values from 'metadata:inputfiles[x]:name' attribute in the mzQC JSON file and thus the value makes a reference to these input files." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-
-[Term]
-id: MS:4000266
-name: Group-label column
-def: "The column contains user-defined names for groups, e.g. 'healthy group' and can be used to give a name to a group of raw files." [PSI:QC]
-is_a: MS:4000107 ! Table column type
-
-[Term]
-id: MS:4000267
-name: PCA table
-def: "A table for the PCA scores of a set of grouped runs, each PCA dimension in a separate column." [PSI:QC]
-comment: The runs need to be labeled with their respective grouping (case/control, timepoints, etc.). The first two PCA dimensions are mandatory, in case more need to be reported, these can be added in optional column as well. While not mandatory, it is recommended to document the features used to calculate the PCA in the file description field.
-is_a: MS:4000006 ! table
-relationship: has_column: MS:4000266 ! group-label
-relationship: has_column: MS:4000246 ! Run name
-relationship: has_column: MS:4000247 ! PCA Dimension 1
-relationship: has_column: MS:4000248 ! PCA Dimension 2
-relationship: has_optional_column: MS:4000249 ! PCA Dimension 3
-relationship: has_optional_column: MS:4000250 ! PCA Dimension 4
-relationship: has_optional_column: MS:4000251 ! PCA Dimension 5
+relationship: has_value_type xsd\:float ! The allowed value-type for this CV term


### PR DESCRIPTION
We now have a more tree-like hierarchy, as 'somewhat similar to is_a' tags are relegated to relationships. There, `has_relationship` is mostly pruned away or converted into `is_a` where there is good inheritance indication. We discussed `associated_with`, sofar no occasion has arisen for that with the QuaMeter ID-free metrics yet. Overall, this results in a less conflated structure. It also means that 'metric discovery' will work less well by DAG traversal (`is_a` builds that) and more via search terms of relations (which IMO is the better way, but doesn't visualise so nicely). As another outcome of this PR I think it would be nice to have derive some CV policies.

About other stanza tags used:
As discussed in the last telcos, we needed more concise names for the relations we want to describe for the terms. The `has_metric_category` and `has_value_concept` give important clues to plotting in a generic setting and unsupervised useage/search. Simple but instructive `has_value_type` will only inform on the data-type, though ultimately this is each implementers own choice. Other info on the values' properties is left to `has_value_concept`. For example informing that the reported values are quantiles. To be complete units should also be provided, `has_columns` will provide value_type, unit and value_concept for tables per  column. In short, here the checklist again:
    Is the metric properly defined?
    Have the is_a specifications proper predecessors and QC metric value types? 
    Has the unit been specified?
    Has the value type been specified?
    Has the value category been specified?
	has_relation -> is_a/remove as non-essential/associated_with

Other notes:
Back when I drafted the Quameter metric representations in our CV, I took the QuameterManual listing of ID-free metrics. Some terms clearly have comments that are not intended to end up in the vocabulary, and indicate where we'd benefit in (definition) refinement from the metrics original creators (@DTabb). I am of the opinion that the comments are a good place to give valuable insight to metric use and special implementation remarks.

Alas, how we organise the additional information in relationships is not without ambiguity. Here are two things we should consider for the value definition of metrics in this PR (and following):
UO:0000191 ! fraction - unit or value_concept? Same for UO:0000189 ! count unit (not all counts though, see density). Same for 'frequencies', hertz implies a frequency. Which way to use and how to avoid mixup in the future?
