### PR TITLE
Switched from master to main branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,9 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
   - cron: "0 0 1 1/1 *" # Run monthly.
 


### PR DESCRIPTION
Correct github action to run on pushes to main branch (new default) instead of old master.