### PR TITLE
Added Z for UTC time zone.

### DIFF
--- a/specification_documents/draft_v1/examples/Mtb-120-outlier-metrics.mzQC
+++ b/specification_documents/draft_v1/examples/Mtb-120-outlier-metrics.mzQC
@@ -1,6 +1,6 @@
 {
   "mzQC": {
-    "creationDate": "2021-06-15T15:04:50",
+    "creationDate": "2021-06-15T15:04:50Z",
     "version": "1.0.0",
     "runQualities": [
       {

--- a/specification_documents/draft_v1/examples/QC2-sample-example.mzQC
+++ b/specification_documents/draft_v1/examples/QC2-sample-example.mzQC
@@ -1,6 +1,6 @@
 {
   "mzQC": {
-    "creationDate": "2020-12-03T19:51:02",
+    "creationDate": "2020-12-03T19:51:02Z",
     "version": "1.0.0",
     "contactName": "Mathias Walzer",
     "contactAddress": "walzer@ebi.ac.uk",

--- a/specification_documents/draft_v1/examples/USI-example.mzQC
+++ b/specification_documents/draft_v1/examples/USI-example.mzQC
@@ -1,6 +1,6 @@
 {
   "mzQC": {
-    "creationDate": "2022-03-16T18:58:45",
+    "creationDate": "2022-03-16T18:58:45Z",
     "version": "1.0.0",
     "contactName": "Mathias Walzer",
     "contactAddress": "walzer@ebi.ac.uk",

--- a/specification_documents/draft_v1/examples/individual-runs.mzQC
+++ b/specification_documents/draft_v1/examples/individual-runs.mzQC
@@ -1,7 +1,7 @@
 {
   "mzQC": {
     "version": "1.0.0",
-    "creationDate": "2020-12-01T11:56:34",
+    "creationDate": "2020-12-01T11:56:34Z",
     "contactName": "Mathias Walzer",
     "contactAddress": "walzer@ebi.ac.uk",
     "description": "A simple mzQC file containing information for a single run.",

--- a/specification_documents/draft_v1/examples/metabo-batches.mzQC
+++ b/specification_documents/draft_v1/examples/metabo-batches.mzQC
@@ -1,6 +1,6 @@
 {
   "mzQC": {
-    "creationDate": "2020-12-09T11:04:16",
+    "creationDate": "2020-12-09T11:04:16Z",
     "contactName": "Mathias Walzer",
     "contactAddress": "walzer@ebi.ac.uk",
     "version": "1.0.0",

--- a/specification_documents/draft_v1/examples/set-of-runs.mzQC
+++ b/specification_documents/draft_v1/examples/set-of-runs.mzQC
@@ -1,7 +1,7 @@
 {
   "mzQC": {
     "version": "1.0.0",
-    "creationDate": "2020-12-01T14:19:09",
+    "creationDate": "2020-12-01T14:19:09Z",
     "contactName": "Chris Bielow",
     "contactAddress": "chris.bielow@bsc.fu-berlin.de",
     "description": "A simple mzQC file containing information for sets of runs.",


### PR DESCRIPTION
This fixes an issue in the example files. 
JSON schema date-time follows RFC3339 https://www.rfc-editor.org/rfc/rfc3339.html#section-5.6
This requires either Z for UTC as a suffix, or a time zone offset. Omission is not permitted.