### PR TITLE
Update mzqc_schema.json

### DIFF
--- a/schema/mzqc_schema.json
+++ b/schema/mzqc_schema.json
@@ -150,7 +150,7 @@
                                         "format": "uri"
                                     }
                                 },
-                                "required": ["version", "uri"]
+                                "required": ["version"]
                             }
                         ]
                     }


### PR DESCRIPTION
fix #315 
`uri` now optional in schema and specdoc